### PR TITLE
Updated ssl-2way to work with ml-gradle 4.x

### DIFF
--- a/examples/ssl-2way-project/build.gradle
+++ b/examples/ssl-2way-project/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+	id "net.saliman.properties" version "1.5.1"
   id "com.marklogic.ml-gradle" version "4.5.2"
 }
 
@@ -77,10 +78,11 @@ if (project.hasProperty("mlKeystore")) {
       KeyManager[] key = keyManagerFactory.getKeyManagers()
 
       // Initialize the SSL context with key and trust managers.
-      SSLContext sslContext = SSLContext.getInstance("SSLv3")
+      SSLContext sslContext = SSLContext.getInstance("TLSv1.2")
       sslContext.init(key, trust, null)
 
       restSslContext = sslContext
+			restTrustManager = trust[0]
 
       // This turns off hostname verification unless mlVerifyServerHostname=true
       if (project.hasProperty("mlVerifyServerHostname") && mlVerifyServerHostname.toBoolean()) {


### PR DESCRIPTION
The previous version used ml-gradle 3.x and Java Client 4. With ml-gradle 4.x using Java Client 5 and higher, an X509TrustManager must be explicitly provided (has to do with the Java Client changing from using Apache HTTP to OkHttp between major versions 4 and 5). Setting `restTrustManager` accomplishes that. 

Also had to bump up the SSL version to the standard TLSv1.2.

This project will receive more updates soon so that it is easier to test with. 