### PR TITLE
Updating the ssl-project example

### DIFF
--- a/examples/ssl-project/README.md
+++ b/examples/ssl-project/README.md
@@ -1,7 +1,12 @@
-This project shows how to use a certificate template to enable SSL connections on an app server (in this case, the
-REST API server). Two things to note in this project:
+This project demonstrates how to use a certificate template to enable SSL connections on an app server. 
 
-1. The src/main/ml-config/servers/rest-api-server.json config file shows an example of referring to the ID of a 
-certificate template.
-1. The gradle.properties file shows how the mlSimpleSsl property is used to tell ml-gradle to use an SSL connection 
-when loading modules. 
+The project currently uses the `mlSimpleSsl` property to tell ml-gradle to use a "trust everything" approach for 
+communicating with the project's REST API server. This is only used for demonstration purposes and is not recommended
+for a production environment. See 
+[this guide on SSL with ml-gradle](https://github.com/marklogic/ml-gradle/wiki/Loading-modules-via-SSL) for 
+information on properly configuring SSL usage. 
+
+Note the inclusion of an `ext` block in this project's `build.gradle` file. This automates the generation of a temp 
+certificate for the certificate template. This can also be accomplished by updating the app server via the MarkLogic
+Admin UI; the Admin UI will check for a temp for the app server's certificate template and will create one if it does
+not yet exist. 

--- a/examples/ssl-project/gradle.properties
+++ b/examples/ssl-project/gradle.properties
@@ -2,13 +2,11 @@ mlHost=localhost
 mlAppName=ssl-project
 mlRestPort=8180
 mlUsername=admin
-mlPassword=admin
+mlPassword=change in gradle-local.properties
 
 # Since the REST API server for this sample project is configured to use a certificate template for SSL, we set this
 # property to use a very simple SSLContext for communicating with the REST API server. This SSLContext is required for
 # loading modules - i.e. in order to load options/services/transforms via the REST API server, we need an SSL connection.
-#
-# You can configure a more sophisticated SSLContext by setting the restSslContext property on mlAppConfig in an ext block in build.gradle.
 #
 # Starting in 3.17.0, there are additional properties for configuring an SSL connection based on the JVM's
 # default keystore. See the Property Reference page in the ml-gradle Wiki for more information.

--- a/examples/ssl-project/src/main/ml-config/servers/README.md
+++ b/examples/ssl-project/src/main/ml-config/servers/README.md
@@ -1,8 +1,0 @@
-The rest-api-server.json file uses a special token that references the ID of a certificate template. This token is
-set during mlDeploy - specifically, after the certificate template has been created or updated. This solves a problem
-where the config file must reference an ID, but there's no way to know what that ID is until the certificate template
-has been created. 
-
-The downside to this approach is that you cannot run a task that updates the server if that task does not also run
-a command to create/update the certificate template; otherwise, ml-gradle will not have a value with which to replace
-the token. 

--- a/examples/ssl-project/src/main/ml-config/servers/rest-api-server.json
+++ b/examples/ssl-project/src/main/ml-config/servers/rest-api-server.json
@@ -1,5 +1,4 @@
 {
   "server-name": "%%NAME%%",
-  "authentication": "digestbasic",
-  "ssl-certificate-template": "%%certificate-templates-id-ssl-project-template%%"
+  "ssl-certificate-template": "ssl-project-template"
 }


### PR DESCRIPTION
In some previous version of MarkLogic, support was added for a certificate template name in a server JSON file, so we don't need the trick anymore of referencing the ID of a certificate template. 