### PR TITLE
DEVEXP-258: Only set arguments not provided by options file when using MlcpTask

### DIFF
--- a/examples/mlcp-project/build.gradle
+++ b/examples/mlcp-project/build.gradle
@@ -65,6 +65,24 @@ task importSampleData(type: com.marklogic.gradle.task.MlcpTask) {
 }
 
 /**
+ * Example of using an options_file with an MlcpTask to import data with mlcp.
+ */
+task importSampleDataWithOptionsFile(type: com.marklogic.gradle.task.MlcpTask) {
+	classpath = configurations.mlcp
+	command = "IMPORT"
+	options_file = "mlcpOptions.txt"
+}
+
+/**
+ * Example of using an JavaExec and an options_file to import data with mlcp.
+ */
+task importSampleDataWithJavaExec(type: JavaExec) {
+	classpath = configurations.mlcp
+	mainClass = 'com.marklogic.contentpump.ContentPump'
+	args = ["IMPORT", "-options_file", "mlcpOptionsHostUsernamePassword.txt"]
+}
+
+/**
  * Example of using mlcp to import RDF data - in this case, World Bank's publicly available topical
  * taxonomy.
  */

--- a/examples/mlcp-project/mlcpOptions.txt
+++ b/examples/mlcp-project/mlcpOptions.txt
@@ -1,0 +1,16 @@
+-host
+localhost
+-username
+admin
+-password
+admin
+-port
+8000
+-database
+mlcp-project-content
+-output_collections
+sample-import
+-output_permissions
+rest-reader,read,rest-writer,update
+-input_file_path
+data/import


### PR DESCRIPTION
Tested manually with a few different gradle tasks and options_files.

Such as:

task importSampleDataWithOptionsFileWithHostUsernamePassword(type: com.marklogic.gradle.task.MlcpTask) {
	classpath = configurations.mlcp
	command = "IMPORT"
	options_file = "mlcpOptionsHostUsernamePassword.txt"
}
