### PR TITLE
DEVEXP-547 Can now select suites and tests to run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 	implementation "com.marklogic:marklogic-data-movement-components:2.6.0"
 	implementation "commons-io:commons-io:2.11.0"
 
-	compileOnly "com.marklogic:marklogic-unit-test-client:1.3.0"
+	compileOnly "com.marklogic:marklogic-unit-test-client:1.4-SNAPSHOT"
 
 	testImplementation localGroovy()
 	testImplementation gradleTestKit()

--- a/examples/unit-test-project/README.md
+++ b/examples/unit-test-project/README.md
@@ -57,12 +57,12 @@ for more information.
 
 You can also access the marklogic-unit-test REST endpoints directly:
 
-- List the tests - http://localhost:8015/v1/resources/marklogic-unit-test
-- Run a test suite - http://localhost:8015/v1/resources/marklogic-unit-test?rs:func=run&rs:suite=My%20Tests
+- List the tests - http://localhost:8115/v1/resources/marklogic-unit-test
+- Run a test suite - http://localhost:8115/v1/resources/marklogic-unit-test?rs:func=run&rs:suite=My%20Tests
 
 And you can run the original UI test runner by going to:
 
-- http://localhost:8015/test/default.xqy
+- http://localhost:8115/test/default.xqy
 
 ## Configuring which server mlUnitTest connects to 
 

--- a/examples/unit-test-project/gradle.properties
+++ b/examples/unit-test-project/gradle.properties
@@ -1,14 +1,14 @@
-mlGradleVersion=4.5.3
-marklogicUnitTestVersion=1.3.0
+mlGradleVersion=4.6-SNAPSHOT
+marklogicUnitTestVersion=1.4-SNAPSHOT
 
 mlHost=localhost
 mlAppName=unit-test-example
-mlRestPort=8014
+mlRestPort=8114
 
 # It's recommend to have two REST servers - one for the app, and one for running tests, which will point to a separate
 # content database as well
 
-mlTestRestPort=8015
+mlTestRestPort=8115
 mlUsername=admin
 mlPassword=admin
 

--- a/src/main/groovy/com/marklogic/gradle/MarkLogicPlugin.groovy
+++ b/src/main/groovy/com/marklogic/gradle/MarkLogicPlugin.groovy
@@ -350,6 +350,8 @@ class MarkLogicPlugin implements Plugin<Project> {
 				"Can use -PsuiteName to override the name of the test suite, -PtestName to override the name of the test module, and -Planguage to specify \"sjs\" or \"xqy\" test code.")
 		project.task("mlUnitTest", type: UnitTestTask, group: unitTestGroup, description: "Run tests found under /test/suites in the modules database. " +
 			"Connects to MarkLogic via the REST API server defined by mlTestRestPort (or by mlRestPort if mlTestRestPort is not set), and uses mlRest* properties for authentication. " +
+			"Use -Psuites to specify one or more suite names, separated by commas, to run. If not set, all suites will be run. " +
+			"Use -Ptests to specify one or more test names, separated by commas, to run. If not set, all tests in a suite will be run. " +
 			"Use -PunitTestResultsPath to override where test result files are written, which defaults to build/test-results/marklogic-unit-test. " +
 			"Use -PrunCodeCoverage to enable code coverage support when running the tests. " +
 			"Use -PrunTeardown and -PrunSuiteTeardown to control whether teardown and suite teardown scripts are run; these default to 'true' and can be set to 'false' instead. ")

--- a/src/main/groovy/com/marklogic/gradle/task/test/UnitTestTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/test/UnitTestTask.groovy
@@ -15,6 +15,7 @@
  */
 package com.marklogic.gradle.task.test
 
+import com.marklogic.client.DatabaseClient
 import com.marklogic.client.ext.DatabaseClientConfig
 import com.marklogic.gradle.task.MarkLogicTask
 import com.marklogic.test.unit.DefaultJUnitTestReporter
@@ -41,47 +42,28 @@ class UnitTestTask extends MarkLogicTask {
 		try {
 			Class.forName("com.marklogic.test.unit.TestManager")
 		} catch (Exception ex) {
-			def message = "This task requires the com.marklogic:marklogic-unit-test-client library to be a buildscript dependency"
+			def message = "This task requires the com.marklogic:marklogic-unit-test-client library to be a buildscript dependency."
 			throw new GradleException(message)
 		}
 
-		def appConfig = getAppConfig()
-
-		def client
-		if (databaseClientConfig.getPort() != null && databaseClientConfig.getPort() > 0) {
-			println "Constructing DatabaseClient based on settings in the databaseClientConfig task property"
-			client = appConfig.configuredDatabaseClientFactory.newDatabaseClient(databaseClientConfig)
-		} else if (appConfig.getTestRestPort() != null) {
-			println "Constructing DatabaseClient that will connect to port: " + appConfig.getTestRestPort()
-			client = appConfig.newTestDatabaseClient()
-		} else {
-			println "Constructing DatabaseClient that will connect to port: " + appConfig.getRestPort()
-			client = appConfig.newDatabaseClient()
-		}
+		def client = createClient()
 
 		try {
 			def testManager = new TestManager(client)
+			def runParams = buildRunParameters()
 
-			boolean runTeardown = true
-			boolean runSuiteTeardown = true
-			boolean runCoverage = false
-			if (project.hasProperty("runTeardown")) {
-				runTeardown = Boolean.parseBoolean(project.property("runTeardown"))
-			}
-			if (project.hasProperty("runSuiteTeardown")) {
-				runSuiteTeardown = Boolean.parseBoolean(project.property("runSuiteTeardown"))
-			}
-			if (project.hasProperty("runCodeCoverage")) {
-				runCoverage = Boolean.parseBoolean(project.property("runCodeCoverage"))
-			}
-
-			println "Run teardown scripts: " + runTeardown
-			println "Run suite teardown scripts: " + runSuiteTeardown
-			println "Run code coverage: " + runCoverage
-			println "Running all suites..."
+			def suites
 			long start = System.currentTimeMillis()
-			def suites = testManager.runAllSuites(runTeardown, runSuiteTeardown, runCoverage)
-			println "Done running all suites; time: " + (System.currentTimeMillis() - start) + "ms"
+			if (project.hasProperty("suites")) {
+				def suitesToRun = project.hasProperty("suites") ? project.property("suites").split(",").toList() : null
+				println "Running suites: " + suitesToRun
+				suites = testManager.runSuites(suitesToRun, runParams)
+			} else {
+				println "Running all suites"
+				suites = testManager.runAllSuites(runParams)
+			}
+			println "Done running suites; time: " + (System.currentTimeMillis() - start) + "ms"
+
 			def report = new DefaultJUnitTestReporter().reportOnJUnitTestSuites(suites)
 			println report
 
@@ -129,6 +111,36 @@ class UnitTestTask extends MarkLogicTask {
 		} finally {
 			client.release()
 		}
+	}
+
+	DatabaseClient createClient() {
+		def appConfig = getAppConfig()
+		if (databaseClientConfig.getPort() != null && databaseClientConfig.getPort() > 0) {
+			println "Constructing DatabaseClient based on settings in the databaseClientConfig task property"
+			return appConfig.configuredDatabaseClientFactory.newDatabaseClient(databaseClientConfig)
+		} else if (appConfig.getTestRestPort() != null) {
+			println "Constructing DatabaseClient that will connect to port: " + appConfig.getTestRestPort()
+			return appConfig.newTestDatabaseClient()
+		}
+		println "Constructing DatabaseClient that will connect to port: " + appConfig.getRestPort()
+		return appConfig.newDatabaseClient()
+	}
+
+	TestManager.RunParameters buildRunParameters() {
+		def runParams = new TestManager.RunParameters()
+		if (project.hasProperty("runTeardown")) {
+			runParams.withRunTeardown(Boolean.parseBoolean(project.property("runTeardown")))
+		}
+		if (project.hasProperty("runSuiteTeardown")) {
+			runParams.withRunSuiteTeardown(Boolean.parseBoolean(project.property("runSuiteTeardown")))
+		}
+		if (project.hasProperty("runCodeCoverage")) {
+			runParams.withCalculateCoverage(Boolean.parseBoolean(project.property("runCodeCoverage")))
+		}
+		if (project.hasProperty("tests")) {
+			runParams.withTestNames(project.property("tests").split(","))
+		}
+		return runParams
 	}
 
 	static String escapeFilename(String filename) {


### PR DESCRIPTION
Updated the unit-test project temporarily with snapshot dependencies for easy local testing before the release. 

Cleaned up UnitTestTask a bit by extracting a couple methods. 