### PR TITLE
Friendlier error message when mlUnitTest bombs

### DIFF
--- a/src/main/groovy/com/marklogic/gradle/task/test/UnitTestTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/test/UnitTestTask.groovy
@@ -106,7 +106,7 @@ class UnitTestTask extends MarkLogicTask {
 			println "\n" + fileCount + " test result files were written to: " + resultsDir
 
 			if (testsFailed) {
-				throw new GradleException("There were failing tests. See the test results at: " + resultsDir)
+				throw new GradleException("There were failing tests. See the test results at: file://" + resultsDir)
 			}
 		} finally {
 			client.release()


### PR DESCRIPTION
Adding "file://" makes the link clickable in an IDE like Intellij, just like how it works when "./gradlew test" fails. 