### PR TITLE
Update to CoRB 2.5.5

### DIFF
--- a/examples/corb2-project/build.gradle
+++ b/examples/corb2-project/build.gradle
@@ -32,17 +32,12 @@ configurations {
     // This configuration captures the dependencies for running CoRB (Content Reprocessing in Bulk).
     // This is only needed if you want to run corb via Gradle tasks.
     // If you do, using com.marklogic.gradle.task.CorbTask is a useful starting point, as shown below.
-    corb {
-        attributes {
-            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        }
-    }
+    corb
 }
 
 dependencies {
     // required to run CoRB2
     corb "com.marklogic:marklogic-corb:${corbVersion}"
-    corb 'com.marklogic:marklogic-xcc:10.0.8'
     // optional
     //corb 'org.jasypt:jasypt:1.9.2' // would be necessary to leverage JasyptDecrypter
 }

--- a/examples/corb2-project/gradle.properties
+++ b/examples/corb2-project/gradle.properties
@@ -1,4 +1,4 @@
-corbVersion=2.5.4
+corbVersion=2.5.5
 mlHost=localhost
 mlAppName=corb2-project
 mlRestPort=8140


### PR DESCRIPTION
CoRB 2.5.5, which now has more simple gradle modules, so dependency no longer needs usage attributes to be set.

Remove explicit XCC dependency, rely on transitive