### PR TITLE
DEVEXP-626 Fixed DeployToReplicaTask

### DIFF
--- a/src/main/groovy/com/marklogic/gradle/task/DeployToReplicaTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/DeployToReplicaTask.groovy
@@ -39,6 +39,6 @@ class DeployToReplicaTask extends MarkLogicTask {
 			commandListSupplier.get() :
 			new CommandMapBuilder().getCommandsForReplicaCluster()
 
-		new SimpleAppDeployer(commands).deploy(getAppConfig())
+		newAppDeployer(commands).deploy(getAppConfig())
 	}
 }


### PR DESCRIPTION
Correctly constructing a deployer. Verified no other occurrences existed of using the deprecated SimpleAppDeployer constructor. 