### PR TITLE
DEVEXP-634 Fixed deletion of module timestamps file

### DIFF
--- a/src/main/groovy/com/marklogic/gradle/task/DeleteModuleTimestampsFileTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/DeleteModuleTimestampsFileTask.groovy
@@ -28,12 +28,16 @@ class DeleteModuleTimestampsFileTask extends MarkLogicTask {
     @TaskAction
     void deleteFile() {
 	    filePath = getAppConfig().getModuleTimestampsPath()
-        File f = new File(filePath)
-        if (f.exists()) {
-            println "Deleting " + f.getAbsolutePath() + "\n"
-            f.delete()
-        } else {
-	        println "Module timestamps file " + filePath + " does not exist, so not deleting"
-        }
+		if (filePath != null && filePath.trim().length() > 0) {
+			File f = new File(filePath)
+			if (f.exists()) {
+				println "Deleting " + f.getAbsolutePath() + "\n"
+				f.delete()
+			} else {
+				println "Module timestamps file " + filePath + " does not exist, so not deleting"
+			}
+		} else {
+			println "Module timestamps file path is not set, so not attempting to delete"
+		}
     }
 }


### PR DESCRIPTION
No longer throws an error when `mlModuleTimestampsPath` is null or empty. Verified manually. 