### PR TITLE
Requiring property values to not be empty

### DIFF
--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/DefaultAppConfigFactory.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/DefaultAppConfigFactory.java
@@ -48,7 +48,9 @@ public class DefaultAppConfigFactory extends PropertySourceFactory implements Ap
 		final AppConfig appConfig = new AppConfig(this.projectDir);
 		for (String propertyName : propertyConsumerMap.keySet()) {
 			String value = getProperty(propertyName);
-			if (value != null) {
+			// In 5.1.0, the value must not be whitespace. But we have this hack here to preserve documented and tested
+			// functionality for allowing for mlModuleTimestampsPath to be set to an empty string to disable its functionality.
+			if (StringUtils.hasText(value) || (value != null && "mlModuleTimestampsPath".equalsIgnoreCase(propertyName))) {
 				try {
 					propertyConsumerMap.get(propertyName).accept(appConfig, value);
 				} catch (Exception ex) {

--- a/ml-app-deployer/src/main/java/com/marklogic/mgmt/DefaultManageConfigFactory.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/mgmt/DefaultManageConfigFactory.java
@@ -261,7 +261,7 @@ public class DefaultManageConfigFactory extends PropertySourceFactory implements
 
 	    for (String propertyName : propertyConsumerMap.keySet()) {
 		    String value = getProperty(propertyName);
-		    if (value != null) {
+		    if (StringUtils.hasText(value)) {
 			    propertyConsumerMap.get(propertyName).accept(config, value);
 		    }
 	    }

--- a/ml-app-deployer/src/main/java/com/marklogic/mgmt/admin/DefaultAdminConfigFactory.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/mgmt/admin/DefaultAdminConfigFactory.java
@@ -244,7 +244,7 @@ public class DefaultAdminConfigFactory extends PropertySourceFactory implements 
 
 	    for (String propertyName : propertyConsumerMap.keySet()) {
 		    String value = getProperty(propertyName);
-		    if (value != null) {
+		    if (StringUtils.hasText(value)) {
 			    propertyConsumerMap.get(propertyName).accept(config, value);
 		    }
 	    }

--- a/ml-app-deployer/src/test/java/com/marklogic/appdeployer/DefaultAppConfigFactoryTest.java
+++ b/ml-app-deployer/src/test/java/com/marklogic/appdeployer/DefaultAppConfigFactoryTest.java
@@ -678,6 +678,19 @@ public class DefaultAppConfigFactoryTest {
 	}
 
 	@Test
+	void blankCloudApiKey() {
+		AppConfig config = configure(
+			"mlCloudApiKey", "",
+			"mlRestBasePath", ""
+		);
+
+		assertNull(config.getCloudApiKey(), "As of 5.0.0, the property factories were only checking for non-null " +
+			"values before applying a property. The expectation now is that an empty string won't result in the " +
+			"property being applied either.");
+		assertNull(config.getRestBasePath());
+	}
+
+	@Test
 	void cloudApiKeyAndBasePath() {
 		AppConfig config = configure(
 			"mlCloudApiKey", "my-key",


### PR DESCRIPTION
I can't think of why this wasn't done before nor what the downside would be to not applying empty strings. Want to see the tests run to see if it causes any failures, implying that this would not be a backwards compatible change.
