### PR TITLE
MLE-20741 Forest replica creation now considers host zone

### DIFF
--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/DeployForestsCommand.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/DeployForestsCommand.java
@@ -166,6 +166,10 @@ public class DeployForestsCommand extends AbstractCommand {
 			if (map != null && map.containsKey(this.databaseName)) {
 				int count = map.get(this.databaseName);
 				if (count > 0) {
+					// Need to pass in host-to-zone mapping.
+					// And what to do about ConfigureForestReplicasCommand??? We may be better off removing that as part of
+					// the 6.0 release so that we only have replica creation in one place. Would need to verify that this command
+					// still works for OOTB databases.
 					forestPlan.withReplicaCount(count);
 				}
 			}

--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestBuilder.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestBuilder.java
@@ -40,7 +40,7 @@ public class ForestBuilder extends LoggingObject {
 
 	public ForestBuilder(ForestNamingStrategy forestNamingStrategy) {
 		this.forestNamingStrategy = forestNamingStrategy;
-		this.replicaBuilderStrategy = new DistributedReplicaBuilderStrategy();
+		this.replicaBuilderStrategy = new ZoneAwareReplicaBuilderStrategy();
 		this.resourceMapper = new DefaultResourceMapper(new API(null));
 	}
 

--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestPlan.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestPlan.java
@@ -20,6 +20,7 @@ import com.marklogic.mgmt.api.forest.Forest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 public class ForestPlan {
 
@@ -30,6 +31,7 @@ public class ForestPlan {
 	private int forestsPerDataDirectory = 1;
 	private List<Forest> existingForests = new ArrayList<>();
 	private int replicaCount = 0;
+	private Map<String, String> hostsToZones;
 
 	public ForestPlan(String databaseName, String... hostNames) {
 		this(databaseName, Arrays.asList(hostNames));
@@ -71,6 +73,11 @@ public class ForestPlan {
 		return this;
 	}
 
+	public ForestPlan withHostsToZones(Map<String, String> hostsToZones) {
+		this.hostsToZones = hostsToZones;
+		return this;
+	}
+
 	public String getDatabaseName() {
 		return databaseName;
 	}
@@ -97,5 +104,9 @@ public class ForestPlan {
 
 	public List<String> getReplicaHostNames() {
 		return replicaHostNames;
+	}
+
+	public Map<String, String> getHostsToZones() {
+		return hostsToZones;
 	}
 }

--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestReplicaPlanner.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestReplicaPlanner.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.appdeployer.command.forests;
+
+import com.marklogic.mgmt.api.forest.Forest;
+import com.marklogic.mgmt.api.forest.ForestReplica;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+class ForestReplicaPlanner {
+
+    static class Host {
+        String name;
+        String zone;
+        List<Forest> forests;
+
+        Host(String hostName, String zone, List<Forest> forests) {
+            this.name = hostName;
+            this.zone = zone;
+            this.forests = forests;
+        }
+
+        Host(String hostName, String zone, String... forests) {
+            this.name = hostName;
+            this.zone = zone;
+            this.forests = new ArrayList<>();
+            for (String forest : forests) {
+                this.forests.add(new Forest(hostName, forest));
+            }
+        }
+    }
+
+    static class ReplicaAssignment {
+        String forest;
+        String originalHost;
+        List<String> replicaHosts;
+
+        ReplicaAssignment(String forest, String originalHost) {
+            this.forest = forest;
+            this.originalHost = originalHost;
+            this.replicaHosts = new ArrayList<>();
+        }
+
+        void addReplicaHost(String host) {
+            replicaHosts.add(host);
+        }
+    }
+
+    static List<ReplicaAssignment> assignReplicas(List<Host> hosts, int replicaCount) {
+        return assignReplicas(hosts, replicaCount, null);
+    }
+
+    /**
+     * @param hosts
+     * @param replicaCount
+     * @param allAvailableHosts is not null for a scenario where e.g. forests for a database are only created on one
+     *                          host, such as for a modules or schemas database. In that scenario, the caller needs to
+     *                          pass in a list of all available hosts in the cluster, so that replicas can be created
+     *                          on those hosts.
+     * @return
+     */
+    static List<ReplicaAssignment> assignReplicas(List<Host> hosts, int replicaCount, List<String> allAvailableHosts) {
+        final List<Host> replicaHosts = buildReplicaHostsList(hosts, allAvailableHosts);
+        final boolean ignoreZones = shouldIgnoreZones(replicaHosts);
+
+        int differentZoneIndex = 0;
+        int sameZoneIndex = 0;
+        final List<ReplicaAssignment> assignments = new ArrayList<>();
+
+        for (final Host host : hosts) {
+            int forestIndex = 0;
+            for (Forest forest : host.forests) {
+                ReplicaAssignment assignment = new ReplicaAssignment(forest.getForestName(), host.name);
+                List<Host> eligibleHosts = buildEligibleHostsList(host, replicaHosts, ignoreZones);
+
+                if (ignoreZones) {
+                    assignReplicasIgnoringZones(assignment, eligibleHosts, replicaCount, forestIndex);
+                } else {
+                    assignReplicasWithZoneAwareness(assignment, eligibleHosts, host, replicaCount, differentZoneIndex, sameZoneIndex);
+                    differentZoneIndex += replicaCount;
+                    sameZoneIndex += replicaCount;
+                }
+
+                addReplicasToForest(forest, assignment);
+                assignments.add(assignment);
+                forestIndex++;
+            }
+        }
+
+        return assignments;
+    }
+
+    private static List<Host> buildReplicaHostsList(List<Host> hosts, List<String> allAvailableHosts) {
+        List<Host> replicaHosts = new ArrayList<>(hosts);
+        if (allAvailableHosts != null) {
+            for (String availableHost : allAvailableHosts) {
+                boolean hostAlreadyExists = hosts.stream().anyMatch(h -> h.name.equals(availableHost));
+                if (!hostAlreadyExists) {
+                    replicaHosts.add(new Host(availableHost, null, new ArrayList<>()));
+                }
+            }
+        }
+        return replicaHosts;
+    }
+
+    private static boolean shouldIgnoreZones(List<Host> replicaHosts) {
+        return replicaHosts.stream().anyMatch(h -> h.zone == null);
+    }
+
+    private static List<Host> buildEligibleHostsList(Host sourceHost, List<Host> replicaHosts, boolean ignoreZones) {
+        List<Host> eligibleHosts = new ArrayList<>();
+        if (ignoreZones) {
+            int sourceIndex = replicaHosts.indexOf(sourceHost);
+            for (int i = 1; i < replicaHosts.size(); i++) {
+                Host candidate = replicaHosts.get((sourceIndex + i) % replicaHosts.size());
+                eligibleHosts.add(candidate);
+            }
+        } else {
+            eligibleHosts = replicaHosts.stream()
+                    .filter(h -> !h.name.equals(sourceHost.name))
+                    .toList();
+        }
+        return eligibleHosts;
+    }
+
+    private static void assignReplicasIgnoringZones(ReplicaAssignment assignment, List<Host> eligibleHosts, int replicaCount, int forestIndex) {
+        Set<String> usedHosts = new HashSet<>();
+        for (int i = 0; i < replicaCount && i < eligibleHosts.size(); i++) {
+            Host targetHost = eligibleHosts.get((forestIndex + i) % eligibleHosts.size());
+            if (!usedHosts.contains(targetHost.name)) {
+                assignment.addReplicaHost(targetHost.name);
+                usedHosts.add(targetHost.name);
+            }
+        }
+    }
+
+    private static void assignReplicasWithZoneAwareness(ReplicaAssignment assignment, List<Host> eligibleHosts, Host sourceHost, int replicaCount, int differentZoneIndex, int sameZoneIndex) {
+        List<Host> differentZoneHosts = new ArrayList<>();
+        List<Host> sameZoneHosts = new ArrayList<>();
+
+        for (Host h : eligibleHosts) {
+            if (h.zone.equals(sourceHost.zone)) {
+                sameZoneHosts.add(h);
+            } else {
+                differentZoneHosts.add(h);
+            }
+        }
+
+        Set<String> usedHosts = new HashSet<>();
+        int replicasAssigned = 0;
+
+        // First, try to assign from different zones
+        replicasAssigned = assignFromHostList(assignment, differentZoneHosts, replicaCount, differentZoneIndex, usedHosts, replicasAssigned);
+
+        // If we still need more replicas, use same-zone hosts
+        assignFromHostList(assignment, sameZoneHosts, replicaCount, sameZoneIndex, usedHosts, replicasAssigned);
+    }
+
+    private static int assignFromHostList(ReplicaAssignment assignment, List<Host> hostList, int replicaCount, int startIndex, Set<String> usedHosts, int replicasAssigned) {
+        while (replicasAssigned < replicaCount && !hostList.isEmpty() && usedHosts.size() < hostList.size()) {
+            Host targetHost = hostList.get(startIndex % hostList.size());
+            startIndex++;
+
+            if (!usedHosts.contains(targetHost.name)) {
+                assignment.addReplicaHost(targetHost.name);
+                usedHosts.add(targetHost.name);
+                replicasAssigned++;
+            }
+        }
+        return replicasAssigned;
+    }
+
+    private static void addReplicasToForest(Forest forest, ReplicaAssignment assignment) {
+        forest.setForestReplica(new ArrayList<>());
+        assignment.replicaHosts.forEach(replicaHost -> {
+            ForestReplica replica = new ForestReplica();
+            replica.setHost(replicaHost);
+            forest.getForestReplica().add(replica);
+        });
+    }
+}

--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ZoneAwareReplicaBuilderStrategy.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ZoneAwareReplicaBuilderStrategy.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.appdeployer.command.forests;
+
+import com.marklogic.appdeployer.AppConfig;
+import com.marklogic.mgmt.api.forest.Forest;
+import com.marklogic.mgmt.api.forest.ForestReplica;
+
+import java.util.*;
+
+/**
+ * Temporarily using this for the logic in MLE-20741. Will eventually replace DistributedReplicaBuilderStrategy with
+ * this, once we know this is all working properly.
+ */
+class ZoneAwareReplicaBuilderStrategy extends AbstractReplicaBuilderStrategy {
+
+	@Override
+	public void buildReplicas(List<Forest> forests, ForestPlan forestPlan, AppConfig appConfig,
+							  List<String> replicaDataDirectories, ForestNamingStrategy forestNamingStrategy) {
+		Map<String, List<Forest>> hostToForests = new LinkedHashMap<>();
+		for (Forest f : forests) {
+			String host = f.getHost();
+			if (hostToForests.containsKey(host)) {
+				hostToForests.get(host).add(f);
+			} else {
+				ArrayList<Forest> hostForests = new ArrayList<>();
+				hostForests.add(f);
+				hostToForests.put(host, hostForests);
+			}
+		}
+
+		List<ForestReplicaPlanner.Host> hosts = new ArrayList<>();
+		hostToForests.forEach((host, hostForests) -> {
+			final String zone = forestPlan.getHostsToZones() != null ? forestPlan.getHostsToZones().get(host) : null;
+			hosts.add(new ForestReplicaPlanner.Host(host, zone, hostForests));
+		});
+
+		ForestReplicaPlanner.assignReplicas(hosts, forestPlan.getReplicaCount(), forestPlan.getReplicaHostNames());
+
+		for (Forest forest : forests) {
+			if (forest.getForestReplica() == null) {
+				continue;
+			}
+			DataDirectoryIterator dataDirectoryIterator = new DataDirectoryIterator(replicaDataDirectories);
+			for (int i = 0; i < forest.getForestReplica().size(); i++) {
+				ForestReplica replica = forest.getForestReplica().get(i);
+				String replicaName = forestNamingStrategy.getReplicaName(forestPlan.getDatabaseName(), forest.getForestName(), i + 1, appConfig);
+				replica.setReplicaName(replicaName);
+				replica.setDataDirectory(dataDirectoryIterator.next());
+				configureReplica(replica, forestPlan.getDatabaseName(), appConfig);
+			}
+		}
+	}
+
+	private static class DataDirectoryIterator implements Iterator<String> {
+
+		private final List<String> dataDirectories;
+		private int index = 0;
+
+		public DataDirectoryIterator(List<String> dataDirectories) {
+			this.dataDirectories = dataDirectories;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return true;
+		}
+
+		@Override
+		public String next() {
+			String value = dataDirectories.get(index);
+			index = (index + 1) % dataDirectories.size();
+			return value;
+		}
+	}
+}

--- a/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/PlanForestReplicasTest.java
+++ b/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/PlanForestReplicasTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.appdeployer.command.forests;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PlanForestReplicasTest {
+
+	@Test
+	void threeHostsOneForestOneReplicaNoZone() {
+		List<ForestReplicaPlanner.Host> hosts = Arrays.asList(
+			new ForestReplicaPlanner.Host("host1", null, "forest1"),
+			new ForestReplicaPlanner.Host("host2", null, "forest2"),
+			new ForestReplicaPlanner.Host("host3", null, "forest3")
+		);
+
+		List<ForestReplicaPlanner.ReplicaAssignment> results = ForestReplicaPlanner.assignReplicas(hosts, 1);
+		assertEquals(3, results.size());
+
+		verifyAssignment(results.get(0), "host2");
+		verifyAssignment(results.get(1), "host3");
+		verifyAssignment(results.get(2), "host1");
+	}
+
+	@Test
+	void threeHostsTwoForestsOneReplicaNoZone() {
+		List<ForestReplicaPlanner.Host> hosts = Arrays.asList(
+			new ForestReplicaPlanner.Host("host1", null, "forest1", "forest2"),
+			new ForestReplicaPlanner.Host("host2", null, "forest3", "forest4"),
+			new ForestReplicaPlanner.Host("host3", null, "forest5", "forest6")
+		);
+
+		List<ForestReplicaPlanner.ReplicaAssignment> results = ForestReplicaPlanner.assignReplicas(hosts, 1);
+		assertEquals(6, results.size());
+
+		verifyAssignment(results.get(0), "host2");
+		verifyAssignment(results.get(1), "host3");
+		verifyAssignment(results.get(2), "host3");
+		verifyAssignment(results.get(3), "host1");
+		verifyAssignment(results.get(4), "host1");
+		verifyAssignment(results.get(5), "host2");
+	}
+
+	@Test
+	void threeHostsOneForestTwoReplicasNoZone() {
+		List<ForestReplicaPlanner.Host> hosts = Arrays.asList(
+			new ForestReplicaPlanner.Host("host1", null, "forest1"),
+			new ForestReplicaPlanner.Host("host2", null, "forest2"),
+			new ForestReplicaPlanner.Host("host3", null, "forest3")
+		);
+
+		List<ForestReplicaPlanner.ReplicaAssignment> results = ForestReplicaPlanner.assignReplicas(hosts, 2);
+		assertEquals(3, results.size());
+
+		verifyAssignment(results.get(0), "host2", "host3");
+		verifyAssignment(results.get(1), "host3", "host1");
+		verifyAssignment(results.get(2), "host1", "host2");
+	}
+
+	@Test
+	void threeHostsTwoForestsTwoReplicasNoZone() {
+		List<ForestReplicaPlanner.Host> hosts = Arrays.asList(
+			new ForestReplicaPlanner.Host("host1", null, "forest1", "forest2"),
+			new ForestReplicaPlanner.Host("host2", null, "forest3", "forest4"),
+			new ForestReplicaPlanner.Host("host3", null, "forest5", "forest6")
+		);
+
+		List<ForestReplicaPlanner.ReplicaAssignment> results = ForestReplicaPlanner.assignReplicas(hosts, 2);
+		assertEquals(6, results.size());
+
+		// This shows how replicas are assigned in a round-robin fashion, with each forest starting with the next
+		// eligible host. Replicas are then created starting with the eligible host and each eligible host after it.
+		// Note that the starting point for replicas for the next forest is not based on where the last replica was
+		// created for the previous forest, but rather based on the next eligible host in the list.
+		verifyAssignment(results.get(0), "host2", "host3");
+		verifyAssignment(results.get(1), "host3", "host2");
+		verifyAssignment(results.get(2), "host3", "host1");
+		verifyAssignment(results.get(3), "host1", "host3");
+		verifyAssignment(results.get(4), "host1", "host2");
+		verifyAssignment(results.get(5), "host2", "host1");
+	}
+
+	@Test
+	void threeHostsOneReplicaThreeZones() {
+		List<ForestReplicaPlanner.Host> hosts = Arrays.asList(
+			new ForestReplicaPlanner.Host("host1", "zoneA", "forest1", "forest2"),
+			new ForestReplicaPlanner.Host("host2", "zoneB", "forest3", "forest4"),
+			new ForestReplicaPlanner.Host("host3", "zoneC", "forest5", "forest6")
+		);
+
+		List<ForestReplicaPlanner.ReplicaAssignment> results = ForestReplicaPlanner.assignReplicas(hosts, 1);
+		assertEquals(6, results.size());
+
+		verifyAssignment(results.get(0), "host2");
+		verifyAssignment(results.get(1), "host3");
+		verifyAssignment(results.get(2), "host1");
+		verifyAssignment(results.get(3), "host3");
+		verifyAssignment(results.get(4), "host1");
+		verifyAssignment(results.get(5), "host2");
+	}
+
+	@Test
+	void threeHostsTwoReplicasThreeZones() {
+		List<ForestReplicaPlanner.Host> hosts = Arrays.asList(
+			new ForestReplicaPlanner.Host("host1", "zoneA", "forest1", "forest2"),
+			new ForestReplicaPlanner.Host("host2", "zoneB", "forest3", "forest4"),
+			new ForestReplicaPlanner.Host("host3", "zoneC", "forest5", "forest6")
+		);
+
+		List<ForestReplicaPlanner.ReplicaAssignment> results = ForestReplicaPlanner.assignReplicas(hosts, 2);
+		assertEquals(6, results.size());
+		verifyAssignment(results.get(0), "host2", "host3");
+		verifyAssignment(results.get(1), "host2", "host3");
+		verifyAssignment(results.get(2), "host1", "host3");
+		verifyAssignment(results.get(3), "host1", "host3");
+		verifyAssignment(results.get(4), "host1", "host2");
+		verifyAssignment(results.get(5), "host1", "host2");
+	}
+
+	@Test
+	void oneZone() {
+		List<ForestReplicaPlanner.Host> hosts = Arrays.asList(
+			new ForestReplicaPlanner.Host("host1", "zoneA", "forest1", "forest2"),
+			new ForestReplicaPlanner.Host("host2", "zoneA", "forest3", "forest4"),
+			new ForestReplicaPlanner.Host("host3", "zoneA", "forest5", "forest6")
+		);
+
+		List<ForestReplicaPlanner.ReplicaAssignment> results = ForestReplicaPlanner.assignReplicas(hosts, 1);
+		assertEquals(6, results.size());
+		verifyAssignment(results.get(0), "host2");
+		verifyAssignment(results.get(1), "host3");
+		verifyAssignment(results.get(2), "host1");
+		verifyAssignment(results.get(3), "host3");
+		verifyAssignment(results.get(4), "host1");
+		verifyAssignment(results.get(5), "host2");
+	}
+
+	@Test
+	void oneZoneSixHostsTwoReplicas() {
+		List<ForestReplicaPlanner.Host> hosts = Arrays.asList(
+			new ForestReplicaPlanner.Host("host1", "zoneA", "forest1", "forest2"),
+			new ForestReplicaPlanner.Host("host2", "zoneA", "forest3", "forest4"),
+			new ForestReplicaPlanner.Host("host3", "zoneA", "forest5", "forest6"),
+			new ForestReplicaPlanner.Host("host4", "zoneA", "forest7", "forest8"),
+			new ForestReplicaPlanner.Host("host5", "zoneA", "forest9", "forest10"),
+			new ForestReplicaPlanner.Host("host6", "zoneA", "forest11", "forest12")
+		);
+
+		List<ForestReplicaPlanner.ReplicaAssignment> results = ForestReplicaPlanner.assignReplicas(hosts, 2);
+		assertEquals(12, results.size());
+
+		// Host1 forests
+		verifyAssignment(results.get(0), "host2", "host3");
+		verifyAssignment(results.get(1), "host4", "host5");
+
+		// Host2 forests
+		verifyAssignment(results.get(2), "host6", "host1");
+		verifyAssignment(results.get(3), "host3", "host4");
+
+		// Host 3 forests
+		verifyAssignment(results.get(4), "host5", "host6");
+		verifyAssignment(results.get(5), "host1", "host2");
+
+		// Host 4 forests
+		verifyAssignment(results.get(6), "host3", "host5");
+		verifyAssignment(results.get(7), "host6", "host1");
+
+		// Host 5 forests
+		verifyAssignment(results.get(8), "host2", "host3");
+		verifyAssignment(results.get(9), "host4", "host6");
+
+		// Host 6 forests
+		verifyAssignment(results.get(10), "host1", "host2");
+		verifyAssignment(results.get(11), "host3", "host4");
+	}
+
+	@Test
+	void fourHostsInTwoZones() {
+		List<ForestReplicaPlanner.Host> hosts = Arrays.asList(
+			new ForestReplicaPlanner.Host("host1", "zoneA", "forest1", "forest2"),
+			new ForestReplicaPlanner.Host("host2", "zoneA", "forest3", "forest4"),
+			new ForestReplicaPlanner.Host("host3", "zoneB", "forest5", "forest6"),
+			new ForestReplicaPlanner.Host("host4", "zoneB", "forest7", "forest8")
+		);
+
+		List<ForestReplicaPlanner.ReplicaAssignment> results = ForestReplicaPlanner.assignReplicas(hosts, 1);
+		results.forEach(System.out::println);
+
+		verifyAssignment(results.get(0), "host3");
+		verifyAssignment(results.get(1), "host4");
+		verifyAssignment(results.get(2), "host3");
+		verifyAssignment(results.get(3), "host4");
+		verifyAssignment(results.get(4), "host1");
+		verifyAssignment(results.get(5), "host2");
+		verifyAssignment(results.get(6), "host1");
+		verifyAssignment(results.get(7), "host2");
+	}
+
+	@Test
+	void sixHostsInThreeZones() {
+		List<ForestReplicaPlanner.Host> hosts = Arrays.asList(
+			new ForestReplicaPlanner.Host("host1", "zoneA", "forest1", "forest2", "forest3"),
+			new ForestReplicaPlanner.Host("host2", "zoneA", "forest4", "forest5", "forest6"),
+			new ForestReplicaPlanner.Host("host3", "zoneB", "forest7", "forest8", "forest9"),
+			new ForestReplicaPlanner.Host("host4", "zoneB", "forest10", "forest11", "forest12"),
+			new ForestReplicaPlanner.Host("host5", "zoneC", "forest13", "forest14", "forest15"),
+			new ForestReplicaPlanner.Host("host6", "zoneC", "forest16", "forest17", "forest18")
+		);
+
+		List<ForestReplicaPlanner.ReplicaAssignment> results = ForestReplicaPlanner.assignReplicas(hosts, 1);
+		assertEquals(18, results.size());
+
+		results.forEach(System.out::println);
+
+		// ZoneA forests
+		verifyAssignment(results.get(0), "host3");
+		verifyAssignment(results.get(1), "host4");
+		verifyAssignment(results.get(2), "host5");
+		verifyAssignment(results.get(3), "host6");
+		verifyAssignment(results.get(4), "host3");
+		verifyAssignment(results.get(5), "host4");
+
+		// ZoneB forests
+		verifyAssignment(results.get(6), "host5");
+		verifyAssignment(results.get(7), "host6");
+		verifyAssignment(results.get(8), "host1");
+		verifyAssignment(results.get(9), "host2");
+		verifyAssignment(results.get(10), "host5");
+		verifyAssignment(results.get(11), "host6");
+
+		// ZoneC forests
+		verifyAssignment(results.get(12), "host1");
+		verifyAssignment(results.get(13), "host2");
+		verifyAssignment(results.get(14), "host3");
+		verifyAssignment(results.get(15), "host4");
+		verifyAssignment(results.get(16), "host1");
+		verifyAssignment(results.get(17), "host2");
+	}
+
+	private void verifyAssignment(ForestReplicaPlanner.ReplicaAssignment assignment, String... expectedReplicaHosts) {
+		assertEquals(expectedReplicaHosts.length, assignment.replicaHosts.size());
+		for (int i = 0; i < assignment.replicaHosts.size(); i++) {
+			assertEquals(expectedReplicaHosts[i], assignment.replicaHosts.get(i),
+				"Unexpected replica host for: " + assignment);
+		}
+	}
+}


### PR DESCRIPTION
This isn't fully baked yet, but it gets the plumbing in place for accounting for a zone value on each host. ForestReplicaPlanner was created almost entirely by Copilot, and it's handling the work of determining which replicas to build and on what hosts.

Next step will be to enhance DeployForestsCommand to actually build the map of hosts to zones, which will then enable the feature.

A final step, and in a separate ticket, will be to figure out what to do with ConfigureForestReplicasCommand. That hopefully is no longer needed, given that DeployForestsCommand is able to create replicas as well.
