### PR TITLE
MLE-20741 Now accounting for zones when creating forest replicas

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,3 +14,103 @@ services:
     ports:
       - "8000-8008:8000-8008"
       - "8028:8028"
+
+  # The six-node cluster defined below is used for manual testing of operations that require a cluster of 3 or more
+  # hosts, such as creating forest replicas.
+  node1:
+    image: "progressofficial/marklogic-db:latest"
+    platform: linux/amd64
+    hostname: node1.local
+    environment:
+      - MARKLOGIC_INIT=true
+      - MARKLOGIC_ADMIN_USERNAME=admin
+      - MARKLOGIC_ADMIN_PASSWORD=admin
+    volumes:
+      - ./docker/marklogic/node1/logs:/var/opt/MarkLogic/Logs
+    ports:
+      - 8100-8103:8000-8003
+
+  node2:
+    image: "progressofficial/marklogic-db:latest"
+    platform: linux/amd64
+    hostname: node2.local
+    depends_on:
+      - node1
+    environment:
+      - MARKLOGIC_INIT=true
+      - MARKLOGIC_ADMIN_USERNAME=admin
+      - MARKLOGIC_ADMIN_PASSWORD=admin
+      - MARKLOGIC_JOIN_CLUSTER=true
+      - MARKLOGIC_BOOTSTRAP_HOST=node1.local
+    volumes:
+      - ./docker/marklogic/node2/logs:/var/opt/MarkLogic/Logs
+    ports:
+      - 8200-8203:8000-8003
+
+  node3:
+    image: "progressofficial/marklogic-db:latest"
+    platform: linux/amd64
+    hostname: node3.local
+    depends_on:
+      - node1
+    environment:
+      - MARKLOGIC_INIT=true
+      - MARKLOGIC_ADMIN_USERNAME=admin
+      - MARKLOGIC_ADMIN_PASSWORD=admin
+      - MARKLOGIC_JOIN_CLUSTER=true
+      - MARKLOGIC_BOOTSTRAP_HOST=node1.local
+    volumes:
+      - ./docker/marklogic/node3/logs:/var/opt/MarkLogic/Logs
+    ports:
+      - 8300-8303:8000-8003
+
+  node4:
+    image: "progressofficial/marklogic-db:latest"
+    platform: linux/amd64
+    hostname: node4.local
+    depends_on:
+      - node1
+    environment:
+      - MARKLOGIC_INIT=true
+      - MARKLOGIC_ADMIN_USERNAME=admin
+      - MARKLOGIC_ADMIN_PASSWORD=admin
+      - MARKLOGIC_JOIN_CLUSTER=true
+      - MARKLOGIC_BOOTSTRAP_HOST=node1.local
+    volumes:
+      - ./docker/marklogic/node4/logs:/var/opt/MarkLogic/Logs
+    ports:
+      - 8500-8503:8000-8003
+
+  node5:
+    image: "progressofficial/marklogic-db:latest"
+    platform: linux/amd64
+    hostname: node5.local
+    depends_on:
+      - node1
+    environment:
+      - MARKLOGIC_INIT=true
+      - MARKLOGIC_ADMIN_USERNAME=admin
+      - MARKLOGIC_ADMIN_PASSWORD=admin
+      - MARKLOGIC_JOIN_CLUSTER=true
+      - MARKLOGIC_BOOTSTRAP_HOST=node1.local
+    volumes:
+      - ./docker/marklogic/node5/logs:/var/opt/MarkLogic/Logs
+    ports:
+      - 8600-8603:8000-8003
+
+  node6:
+    image: "progressofficial/marklogic-db:latest"
+    platform: linux/amd64
+    hostname: node6.local
+    depends_on:
+      - node1
+    environment:
+      - MARKLOGIC_INIT=true
+      - MARKLOGIC_ADMIN_USERNAME=admin
+      - MARKLOGIC_ADMIN_PASSWORD=admin
+      - MARKLOGIC_JOIN_CLUSTER=true
+      - MARKLOGIC_BOOTSTRAP_HOST=node1.local
+    volumes:
+      - ./docker/marklogic/node6/logs:/var/opt/MarkLogic/Logs
+    ports:
+      - 8700-8703:8000-8003

--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestPlan.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestPlan.java
@@ -68,11 +68,23 @@ public class ForestPlan {
 		return this;
 	}
 
+	/**
+	 * Confusingly, this is only used - at least as of 6.0.0 - when previewing forest creation. It is not used when
+	 * actually configuring forest replicas.
+	 *
+	 * @param replicaHostNames
+	 * @return
+	 */
 	public ForestPlan withReplicaHostNames(List<String> replicaHostNames) {
 		this.replicaHostNames = replicaHostNames;
 		return this;
 	}
 
+	/**
+	 * @param hostsToZones a mapping of each host name to an optional zone value for each host. The zone value can be
+	 *                     null for a host.
+	 * @since 6.0.0
+	 */
 	public ForestPlan withHostsToZones(Map<String, String> hostsToZones) {
 		this.hostsToZones = hostsToZones;
 		return this;
@@ -106,6 +118,10 @@ public class ForestPlan {
 		return replicaHostNames;
 	}
 
+	/**
+	 * @return
+	 * @since 6.0.0
+	 */
 	public Map<String, String> getHostsToZones() {
 		return hostsToZones;
 	}

--- a/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/ConfigureForestReplicasDebug.java
+++ b/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/ConfigureForestReplicasDebug.java
@@ -22,27 +22,30 @@ import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.ManageConfig;
 import com.marklogic.mgmt.resource.hosts.HostManager;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Not an actual test, as this depends on an environment with multiple hosts, which is normally not the case on a
  * development machine.
+ * <p>
+ * This is now intended to run against the multi-host cluster setup via docker-compose.yml.
  */
 public class ConfigureForestReplicasDebug {
 
 	public static void main(String[] args) {
 		final String host = "localhost"; //args[0];
 		final String password = "admin"; //args[1];
-
 		final String dbName = "testdb";
+		final int replicaCount = 2;
 
-		ManageConfig config = new ManageConfig(host, 8002, "admin", password);
+		ManageConfig config = new ManageConfig(host, 8102, "admin", password);
 		ManageClient manageClient = new ManageClient(config);
 
 		AppConfig appConfig = new AppConfig();
-		Map<String, Integer> map = new HashMap<>();
-		map.put(dbName, 2);
-		appConfig.setDatabaseNamesAndReplicaCounts(map);
+		appConfig.setDatabaseNamesAndReplicaCounts(Map.of(dbName, replicaCount));
 
 		List<String> hostNames = new HostManager(manageClient).getHostNames();
 


### PR DESCRIPTION
This hooks up the host-to-zone mapping so that it's fed into the forest replica planner. Currently only being tested via manual testing, which is consistent with how "real" replicas have been created in the past.

Enhanced the docker-compose file to create a 6-host cluster for manual testing purposes.

Story isn't quite done though. Need to add some tests for creating forests on a single host, as that seems a bit off.
