### PR TITLE
MLE-20741 Zone-aware replicas created when forests on single host

### DIFF
--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestReplicaPlanner.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestReplicaPlanner.java
@@ -5,6 +5,8 @@ package com.marklogic.appdeployer.command.forests;
 
 import com.marklogic.mgmt.api.forest.Forest;
 import com.marklogic.mgmt.api.forest.ForestReplica;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -13,173 +15,186 @@ import java.util.Set;
 
 class ForestReplicaPlanner {
 
-    static class Host {
-        String name;
-        String zone;
-        List<Forest> forests;
+	private static final Logger logger = LoggerFactory.getLogger(ForestReplicaPlanner.class);
 
-        Host(String hostName, String zone, List<Forest> forests) {
-            this.name = hostName;
-            this.zone = zone;
-            this.forests = forests;
-        }
+	static class Host {
+		String name;
+		String zone;
+		List<Forest> forests;
 
-        Host(String hostName, String zone, String... forests) {
-            this.name = hostName;
-            this.zone = zone;
-            this.forests = new ArrayList<>();
-            for (String forest : forests) {
-                this.forests.add(new Forest(hostName, forest));
-            }
-        }
-    }
+		Host(String hostName, String zone, List<Forest> forests) {
+			this.name = hostName;
+			this.zone = zone;
+			this.forests = forests;
+		}
 
-    static class ReplicaAssignment {
-        String forest;
-        String originalHost;
-        List<String> replicaHosts;
+		Host(String hostName, String zone, String... forests) {
+			this.name = hostName;
+			this.zone = zone;
+			this.forests = new ArrayList<>();
+			for (String forest : forests) {
+				this.forests.add(new Forest(hostName, forest));
+			}
+		}
 
-        ReplicaAssignment(String forest, String originalHost) {
-            this.forest = forest;
-            this.originalHost = originalHost;
-            this.replicaHosts = new ArrayList<>();
-        }
+		@Override
+		public String toString() {
+			return "[Host: %s; zone: %s]".formatted(name, zone);
+		}
+	}
 
-        void addReplicaHost(String host) {
-            replicaHosts.add(host);
-        }
-    }
+	static class ReplicaAssignment {
+		String forest;
+		String originalHost;
+		List<String> replicaHosts;
 
-    static List<ReplicaAssignment> assignReplicas(List<Host> hosts, int replicaCount) {
-        return assignReplicas(hosts, replicaCount, null);
-    }
+		ReplicaAssignment(String forest, String originalHost) {
+			this.forest = forest;
+			this.originalHost = originalHost;
+			this.replicaHosts = new ArrayList<>();
+		}
 
-    /**
-     * @param hosts
-     * @param replicaCount
-     * @param allAvailableHosts is not null for a scenario where e.g. forests for a database are only created on one
-     *                          host, such as for a modules or schemas database. In that scenario, the caller needs to
-     *                          pass in a list of all available hosts in the cluster, so that replicas can be created
-     *                          on those hosts.
-     * @return
-     */
-    static List<ReplicaAssignment> assignReplicas(List<Host> hosts, int replicaCount, List<String> allAvailableHosts) {
-        final List<Host> replicaHosts = buildReplicaHostsList(hosts, allAvailableHosts);
-        final boolean ignoreZones = shouldIgnoreZones(replicaHosts);
+		void addReplicaHost(String host) {
+			replicaHosts.add(host);
+		}
+	}
 
-        int differentZoneIndex = 0;
-        int sameZoneIndex = 0;
-        final List<ReplicaAssignment> assignments = new ArrayList<>();
+	static List<ReplicaAssignment> assignReplicas(List<Host> hosts, int replicaCount) {
+		return assignReplicas(hosts, replicaCount, null);
+	}
 
-        for (final Host host : hosts) {
-            int forestIndex = 0;
-            for (Forest forest : host.forests) {
-                ReplicaAssignment assignment = new ReplicaAssignment(forest.getForestName(), host.name);
-                List<Host> eligibleHosts = buildEligibleHostsList(host, replicaHosts, ignoreZones);
+	/**
+	 * @param hosts             list of hosts containing primary forests.
+	 * @param replicaCount      number of replica forests to create for each primary forest.
+	 * @param allAvailableHosts is not null for a scenario where e.g. forests for a database are only created on one
+	 *                          host, such as for a modules or schemas database. In that scenario, the caller needs to
+	 *                          pass in a list of all available hosts in the cluster, so that replicas can be created
+	 *                          on those hosts.
+	 * @return
+	 */
+	static List<ReplicaAssignment> assignReplicas(List<Host> hosts, int replicaCount, List<Host> allAvailableHosts) {
+		final List<Host> replicaHosts = buildReplicaHostsList(hosts, allAvailableHosts);
+		final boolean ignoreZones = shouldIgnoreZones(replicaHosts);
 
-                if (ignoreZones) {
-                    assignReplicasIgnoringZones(assignment, eligibleHosts, replicaCount, forestIndex);
-                } else {
-                    assignReplicasWithZoneAwareness(assignment, eligibleHosts, host, replicaCount, differentZoneIndex, sameZoneIndex);
-                    differentZoneIndex += replicaCount;
-                    sameZoneIndex += replicaCount;
-                }
+		int differentZoneIndex = 0;
+		int sameZoneIndex = 0;
+		final List<ReplicaAssignment> assignments = new ArrayList<>();
 
-                addReplicasToForest(forest, assignment);
-                assignments.add(assignment);
-                forestIndex++;
-            }
-        }
+		for (final Host host : hosts) {
+			int forestIndex = 0;
+			for (Forest forest : host.forests) {
+				ReplicaAssignment assignment = new ReplicaAssignment(forest.getForestName(), host.name);
+				List<Host> eligibleHosts = buildEligibleHostsList(host, replicaHosts, ignoreZones);
 
-        return assignments;
-    }
+				if (ignoreZones) {
+					assignReplicasIgnoringZones(assignment, eligibleHosts, replicaCount, forestIndex);
+				} else {
+					assignReplicasWithZoneAwareness(assignment, eligibleHosts, host, replicaCount, differentZoneIndex, sameZoneIndex);
+					differentZoneIndex += replicaCount;
+					sameZoneIndex += replicaCount;
+				}
 
-    private static List<Host> buildReplicaHostsList(List<Host> hosts, List<String> allAvailableHosts) {
-        List<Host> replicaHosts = new ArrayList<>(hosts);
-        if (allAvailableHosts != null) {
-            for (String availableHost : allAvailableHosts) {
-                boolean hostAlreadyExists = hosts.stream().anyMatch(h -> h.name.equals(availableHost));
-                if (!hostAlreadyExists) {
-                    replicaHosts.add(new Host(availableHost, null, new ArrayList<>()));
-                }
-            }
-        }
-        return replicaHosts;
-    }
+				addReplicasToForest(forest, assignment);
+				assignments.add(assignment);
+				forestIndex++;
+			}
+		}
 
-    private static boolean shouldIgnoreZones(List<Host> replicaHosts) {
-        return replicaHosts.stream().anyMatch(h -> h.zone == null);
-    }
+		return assignments;
+	}
 
-    private static List<Host> buildEligibleHostsList(Host sourceHost, List<Host> replicaHosts, boolean ignoreZones) {
-        List<Host> eligibleHosts = new ArrayList<>();
-        if (ignoreZones) {
-            int sourceIndex = replicaHosts.indexOf(sourceHost);
-            for (int i = 1; i < replicaHosts.size(); i++) {
-                Host candidate = replicaHosts.get((sourceIndex + i) % replicaHosts.size());
-                eligibleHosts.add(candidate);
-            }
-        } else {
-            eligibleHosts = replicaHosts.stream()
-                    .filter(h -> !h.name.equals(sourceHost.name))
-                    .toList();
-        }
-        return eligibleHosts;
-    }
+	private static List<Host> buildReplicaHostsList(List<Host> hosts, List<Host> allAvailableHosts) {
+		List<Host> replicaHosts = new ArrayList<>(hosts);
+		if (allAvailableHosts != null) {
+			for (Host availableHost : allAvailableHosts) {
+				boolean hostAlreadyExists = hosts.stream().anyMatch(h -> h.name.equals(availableHost.name));
+				if (!hostAlreadyExists) {
+					replicaHosts.add(availableHost);
+				}
+			}
+		}
+		return replicaHosts;
+	}
 
-    private static void assignReplicasIgnoringZones(ReplicaAssignment assignment, List<Host> eligibleHosts, int replicaCount, int forestIndex) {
-        Set<String> usedHosts = new HashSet<>();
-        for (int i = 0; i < replicaCount && i < eligibleHosts.size(); i++) {
-            Host targetHost = eligibleHosts.get((forestIndex + i) % eligibleHosts.size());
-            if (!usedHosts.contains(targetHost.name)) {
-                assignment.addReplicaHost(targetHost.name);
-                usedHosts.add(targetHost.name);
-            }
-        }
-    }
+	private static boolean shouldIgnoreZones(List<Host> replicaHosts) {
+		return replicaHosts.stream().anyMatch(h -> h.zone == null);
+	}
 
-    private static void assignReplicasWithZoneAwareness(ReplicaAssignment assignment, List<Host> eligibleHosts, Host sourceHost, int replicaCount, int differentZoneIndex, int sameZoneIndex) {
-        List<Host> differentZoneHosts = new ArrayList<>();
-        List<Host> sameZoneHosts = new ArrayList<>();
+	private static List<Host> buildEligibleHostsList(Host sourceHost, List<Host> replicaHosts, boolean ignoreZones) {
+		List<Host> eligibleHosts = new ArrayList<>();
+		if (ignoreZones) {
+			int sourceIndex = replicaHosts.indexOf(sourceHost);
+			for (int i = 1; i < replicaHosts.size(); i++) {
+				Host candidate = replicaHosts.get((sourceIndex + i) % replicaHosts.size());
+				eligibleHosts.add(candidate);
+			}
+		} else {
+			eligibleHosts = replicaHosts.stream()
+				.filter(h -> !h.name.equals(sourceHost.name))
+				.toList();
+		}
+		return eligibleHosts;
+	}
 
-        for (Host h : eligibleHosts) {
-            if (h.zone.equals(sourceHost.zone)) {
-                sameZoneHosts.add(h);
-            } else {
-                differentZoneHosts.add(h);
-            }
-        }
+	private static void assignReplicasIgnoringZones(ReplicaAssignment assignment, List<Host> eligibleHosts, int replicaCount, int forestIndex) {
+		if (logger.isDebugEnabled()) {
+			logger.debug("Assigning replicas without considering host zones.");
+		}
+		Set<String> usedHosts = new HashSet<>();
+		for (int i = 0; i < replicaCount && i < eligibleHosts.size(); i++) {
+			Host targetHost = eligibleHosts.get((forestIndex + i) % eligibleHosts.size());
+			if (!usedHosts.contains(targetHost.name)) {
+				assignment.addReplicaHost(targetHost.name);
+				usedHosts.add(targetHost.name);
+			}
+		}
+	}
 
-        Set<String> usedHosts = new HashSet<>();
-        int replicasAssigned = 0;
+	private static void assignReplicasWithZoneAwareness(ReplicaAssignment assignment, List<Host> eligibleHosts, Host sourceHost, int replicaCount, int differentZoneIndex, int sameZoneIndex) {
+		if (logger.isDebugEnabled()) {
+			logger.debug("Assigning replicas while taking host zones into account.");
+		}
+		List<Host> differentZoneHosts = new ArrayList<>();
+		List<Host> sameZoneHosts = new ArrayList<>();
 
-        // First, try to assign from different zones
-        replicasAssigned = assignFromHostList(assignment, differentZoneHosts, replicaCount, differentZoneIndex, usedHosts, replicasAssigned);
+		for (Host h : eligibleHosts) {
+			if (h.zone.equals(sourceHost.zone)) {
+				sameZoneHosts.add(h);
+			} else {
+				differentZoneHosts.add(h);
+			}
+		}
 
-        // If we still need more replicas, use same-zone hosts
-        assignFromHostList(assignment, sameZoneHosts, replicaCount, sameZoneIndex, usedHosts, replicasAssigned);
-    }
+		Set<String> usedHosts = new HashSet<>();
+		int replicasAssigned = 0;
 
-    private static int assignFromHostList(ReplicaAssignment assignment, List<Host> hostList, int replicaCount, int startIndex, Set<String> usedHosts, int replicasAssigned) {
-        while (replicasAssigned < replicaCount && !hostList.isEmpty() && usedHosts.size() < hostList.size()) {
-            Host targetHost = hostList.get(startIndex % hostList.size());
-            startIndex++;
+		// First, try to assign from different zones
+		replicasAssigned = assignFromHostList(assignment, differentZoneHosts, replicaCount, differentZoneIndex, usedHosts, replicasAssigned);
 
-            if (!usedHosts.contains(targetHost.name)) {
-                assignment.addReplicaHost(targetHost.name);
-                usedHosts.add(targetHost.name);
-                replicasAssigned++;
-            }
-        }
-        return replicasAssigned;
-    }
+		// If we still need more replicas, use same-zone hosts
+		assignFromHostList(assignment, sameZoneHosts, replicaCount, sameZoneIndex, usedHosts, replicasAssigned);
+	}
 
-    private static void addReplicasToForest(Forest forest, ReplicaAssignment assignment) {
-        forest.setForestReplica(new ArrayList<>());
-        assignment.replicaHosts.forEach(replicaHost -> {
-            ForestReplica replica = new ForestReplica();
-            replica.setHost(replicaHost);
-            forest.getForestReplica().add(replica);
-        });
-    }
+	private static int assignFromHostList(ReplicaAssignment assignment, List<Host> hostList, int replicaCount, int startIndex, Set<String> usedHosts, int replicasAssigned) {
+		while (replicasAssigned < replicaCount && !hostList.isEmpty() && usedHosts.size() < hostList.size()) {
+			Host targetHost = hostList.get(startIndex % hostList.size());
+			startIndex++;
+
+			if (!usedHosts.contains(targetHost.name)) {
+				assignment.addReplicaHost(targetHost.name);
+				usedHosts.add(targetHost.name);
+				replicasAssigned++;
+			}
+		}
+		return replicasAssigned;
+	}
+
+	private static void addReplicasToForest(Forest forest, ReplicaAssignment assignment) {
+		forest.setForestReplica(new ArrayList<>());
+		assignment.replicaHosts.forEach(replicaHost -> {
+			ForestReplica replica = new ForestReplica();
+			replica.setHost(replicaHost);
+			forest.getForestReplica().add(replica);
+		});
+	}
 }

--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ZoneAwareReplicaBuilderStrategy.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ZoneAwareReplicaBuilderStrategy.java
@@ -30,13 +30,22 @@ class ZoneAwareReplicaBuilderStrategy extends AbstractReplicaBuilderStrategy {
 			}
 		}
 
-		List<ForestReplicaPlanner.Host> hosts = new ArrayList<>();
+		final List<ForestReplicaPlanner.Host> hosts = new ArrayList<>();
 		hostToForests.forEach((host, hostForests) -> {
 			final String zone = forestPlan.getHostsToZones() != null ? forestPlan.getHostsToZones().get(host) : null;
 			hosts.add(new ForestReplicaPlanner.Host(host, zone, hostForests));
 		});
 
-		ForestReplicaPlanner.assignReplicas(hosts, forestPlan.getReplicaCount(), forestPlan.getReplicaHostNames());
+		List<ForestReplicaPlanner.Host> allAvailableHosts = null;
+		if (forestPlan.getReplicaHostNames() != null) {
+			allAvailableHosts = new ArrayList<>();
+			for (String hostName : forestPlan.getReplicaHostNames()) {
+				final String zone = forestPlan.getHostsToZones() != null ? forestPlan.getHostsToZones().get(hostName) : null;
+				allAvailableHosts.add(new ForestReplicaPlanner.Host(hostName, zone));
+			}
+		}
+
+		ForestReplicaPlanner.assignReplicas(hosts, forestPlan.getReplicaCount(), allAvailableHosts);
 
 		for (Forest forest : forests) {
 			if (forest.getForestReplica() == null) {

--- a/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/ConfigureForestReplicasDebug.java
+++ b/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/ConfigureForestReplicasDebug.java
@@ -20,12 +20,9 @@ import com.marklogic.appdeployer.command.CommandContext;
 import com.marklogic.appdeployer.command.databases.DeployDatabaseCommand;
 import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.ManageConfig;
-import com.marklogic.mgmt.resource.hosts.HostManager;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Not an actual test, as this depends on an environment with multiple hosts, which is normally not the case on a
@@ -38,48 +35,34 @@ public class ConfigureForestReplicasDebug {
 	public static void main(String[] args) {
 		final String host = "localhost"; //args[0];
 		final String password = "admin"; //args[1];
+		final int managePort = 8102;
 		final String dbName = "testdb";
 		final int replicaCount = 2;
 
-		ManageConfig config = new ManageConfig(host, 8102, "admin", password);
-		ManageClient manageClient = new ManageClient(config);
+		ManageClient manageClient = new ManageClient(new ManageConfig(host, managePort, "admin", password));
 
-		AppConfig appConfig = new AppConfig();
+		final AppConfig appConfig = new AppConfig();
+		appConfig.setDatabasesWithForestsOnOneHost(Set.of(dbName));
 		appConfig.setDatabaseNamesAndReplicaCounts(Map.of(dbName, replicaCount));
 
-		List<String> hostNames = new HostManager(manageClient).getHostNames();
+		final CommandContext context = new CommandContext(appConfig, manageClient, null);
 
-		Map<String, List<String>> databaseHosts = new LinkedHashMap<>();
-		List<String> hosts = new ArrayList<>();
-		hosts.add(hostNames.get(0));
-		hosts.add(hostNames.get(1));
-		databaseHosts.put(dbName, hosts);
-		//appConfig.setDatabaseHosts(databaseHosts);
+		DeployDatabaseCommand deployDatabaseCommand = new DeployDatabaseCommand();
+		deployDatabaseCommand.setForestsPerHost(2);
+		deployDatabaseCommand.setCreateDatabaseWithoutFile(true);
+		deployDatabaseCommand.setDatabaseName(dbName);
 
-		Map<String, List<String>> databaseGroups = new LinkedHashMap<>();
-		List<String> groups = new ArrayList<>();
-		groups.add("Default");
-		databaseGroups.put(dbName, groups);
-		//appConfig.setDatabaseGroups(databaseGroups);
+		// Deploy the database.
+		deployDatabaseCommand.execute(context);
 
-		CommandContext context = new CommandContext(appConfig, manageClient, null);
-
-		DeployDatabaseCommand ddc = new DeployDatabaseCommand();
-		ddc.setForestsPerHost(2);
-		ddc.setCreateDatabaseWithoutFile(true);
-		ddc.setDatabaseName(dbName);
-
-		ConfigureForestReplicasCommand cfrc = new ConfigureForestReplicasCommand();
-
-		// Deploy the database, and then configure replicas
-		ddc.execute(context);
-		cfrc.execute(context);
-
+		// Configure replicas.
+		ConfigureForestReplicasCommand configureForestReplicasCommand = new ConfigureForestReplicasCommand();
+		configureForestReplicasCommand.execute(context);
 		// Deploy again to make sure there are no errors
-		cfrc.execute(context);
+		configureForestReplicasCommand.execute(context);
 
-		// Then delete the replicas, and then undeploy the database
-		cfrc.undo(context);
-		ddc.undo(context);
+		// Delete replicas, and then the database.
+		configureForestReplicasCommand.undo(context);
+		deployDatabaseCommand.undo(context);
 	}
 }

--- a/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/PlanForestReplicasTest.java
+++ b/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/PlanForestReplicasTest.java
@@ -216,8 +216,6 @@ class PlanForestReplicasTest {
 		List<ForestReplicaPlanner.ReplicaAssignment> results = ForestReplicaPlanner.assignReplicas(hosts, 1);
 		assertEquals(18, results.size());
 
-		results.forEach(System.out::println);
-
 		// ZoneA forests
 		verifyAssignment(results.get(0), "host3");
 		verifyAssignment(results.get(1), "host4");


### PR DESCRIPTION
This is for a scenario where all forests for a database are on a single host, which is often done for modules/schemas databases.
