### PR TITLE
MLE-22812 Refactor: Created ForestPlanner

### DIFF
--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestPlanner.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestPlanner.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.appdeployer.command.forests;
+
+import com.marklogic.appdeployer.AppConfig;
+import com.marklogic.appdeployer.command.CommandContext;
+import com.marklogic.appdeployer.command.databases.DatabasePlan;
+import com.marklogic.appdeployer.command.databases.DeployDatabaseCommand;
+import com.marklogic.appdeployer.command.databases.DeployOtherDatabasesCommand;
+import com.marklogic.mgmt.ManageClient;
+import com.marklogic.mgmt.api.forest.Forest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Intended to be the central interface for "Give me a database name and a set of inputs, and I'll give you back a list
+ * of forests with replicas that should be created for that database". We'll sort out the naming of this and the
+ * related classes later.
+ */
+public class ForestPlanner {
+
+    private final ManageClient manageClient;
+
+    public ForestPlanner(ManageClient manageClient) {
+        this.manageClient = manageClient;
+    }
+
+    public List<Forest> previewForestPlan(String database, AppConfig appConfig) {
+        // We unfortunately still need a CommandContext here, even though this is just for previewing forests. The
+        // classes that this depends on would need to be modified first to only require an AppConfig and/or ManageClient.
+        final CommandContext context = new CommandContext(appConfig, this.manageClient, null);
+
+        List<DatabasePlan> plans = new DeployOtherDatabasesCommand().buildDatabasePlans(context);
+        DeployDatabaseCommand dbCommand = null;
+        for (DatabasePlan plan : plans) {
+            if (plan.getDatabaseName().equals(database)) {
+                dbCommand = plan.getDeployDatabaseCommand();
+                break;
+            }
+        }
+        if (dbCommand == null) {
+            throw new IllegalArgumentException("Did not find any database plan with a database name of: " + database);
+        }
+
+        DeployForestsCommand deployForestsCommand = dbCommand.buildDeployForestsCommand(database, context);
+        return deployForestsCommand != null ?
+                deployForestsCommand.buildForests(context, true) :
+                new ArrayList<>();
+    }
+}

--- a/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/ForestPlannerTest.java
+++ b/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/ForestPlannerTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.appdeployer.command.forests;
+
+import com.marklogic.appdeployer.AbstractAppDeployerTest;
+import com.marklogic.mgmt.api.forest.Forest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ForestPlannerTest extends AbstractAppDeployerTest {
+
+	private static final String DB_NAME = "sample-app-content";
+
+	@Test
+	void test() {
+		List<Forest> forests = new ForestPlanner(manageClient).previewForestPlan(DB_NAME, appConfig);
+		assertEquals(3, forests.size());
+		assertEquals("sample-app-content-1", forests.get(0).getForestName());
+		assertEquals("sample-app-content-2", forests.get(1).getForestName());
+		assertEquals("sample-app-content-3", forests.get(2).getForestName());
+	}
+}


### PR DESCRIPTION
This is just to move as much logic out of the Gradle task (hard to test) into a regular Java class in ml-app-deployer (easy to test).
