### PR TITLE
MLE-22812 Refactor: Only configuring replicas in one place

### DIFF
--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/databases/DeployOtherDatabasesCommand.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/databases/DeployOtherDatabasesCommand.java
@@ -404,7 +404,7 @@ public class DeployOtherDatabasesCommand extends AbstractUndoableCommand {
 				dbConfig.addDatabase(convertPayloadToObjectNode(context, payload));
 				DeployForestsCommand deployForestsCommand = deployDatabaseCommand.buildDeployForestsCommand(plan.getDatabaseName(), context);
 				if (deployForestsCommand != null) {
-					deployForestsCommand.buildForests(context, false).forEach(forest -> forestConfig.addForest(forest.toObjectNode()));
+					deployForestsCommand.buildForests(context).forEach(forest -> forestConfig.addForest(forest.toObjectNode()));
 				}
 			}
 		});
@@ -430,7 +430,7 @@ public class DeployOtherDatabasesCommand extends AbstractUndoableCommand {
 		databasePlans.forEach(plan -> {
 			DeployForestsCommand dfc = plan.getDeployDatabaseCommand().getDeployForestsCommand();
 			if (dfc != null) {
-				allForests.addAll(dfc.buildForests(context, false));
+				allForests.addAll(dfc.buildForests(context));
 			}
 		});
 		if (!allForests.isEmpty()) {

--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/DefaultHostCalculator.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/DefaultHostCalculator.java
@@ -38,29 +38,25 @@ public class DefaultHostCalculator extends LoggingObject implements HostCalculat
 		if (candidateHostNames.isEmpty()) {
 			throw new RuntimeException("Unable to determine host names for forests for database: " + databaseName + "; please check the " +
 				"properties you've set for creating forests for this database to ensure that forests can be created on at " +
-				"least one host in your cluster");
+				"least one host in your cluster.");
 		}
 
 		final List<String> primaryForestHostNames = new ArrayList<>();
-		final List<String> replicaForestHostNames = new ArrayList<>();
 
 		if (context.getAppConfig().isDatabaseWithForestsOnOneHost(databaseName)) {
 			if (existingPrimaryForests.size() > 0) {
 				primaryForestHostNames.add(existingPrimaryForests.get(0).getHost());
-				replicaForestHostNames.addAll(candidateHostNames);
 			} else {
 				primaryForestHostNames.add(candidateHostNames.get(0));
-				replicaForestHostNames.addAll(candidateHostNames);
 			}
 		} else {
 			primaryForestHostNames.addAll(candidateHostNames);
-			replicaForestHostNames.addAll(candidateHostNames);
 		}
 
-		return new ForestHostNames(primaryForestHostNames, replicaForestHostNames);
+		return new ForestHostNames(primaryForestHostNames);
 	}
 
-	protected List<String> getCandidateHostNames(String databaseName, CommandContext context) {
+	private List<String> getCandidateHostNames(String databaseName, CommandContext context) {
 		if (logger.isInfoEnabled()) {
 			logger.info("Finding eligible hosts for forests for database: " + databaseName);
 		}
@@ -83,7 +79,7 @@ public class DefaultHostCalculator extends LoggingObject implements HostCalculat
 	 * @param context
 	 * @return
 	 */
-	protected List<String> determineHostNamesBasedOnDatabaseGroups(String databaseName, CommandContext context) {
+	private List<String> determineHostNamesBasedOnDatabaseGroups(String databaseName, CommandContext context) {
 		Map<String, List<String>> databaseGroups = context.getAppConfig().getDatabaseGroups();
 		if (databaseGroups != null) {
 			List<String> selectedGroupNames = databaseGroups.get(databaseName);
@@ -134,7 +130,7 @@ public class DefaultHostCalculator extends LoggingObject implements HostCalculat
 	 * @param hostNames
 	 * @return
 	 */
-	protected List<String> determineHostNamesBasedOnDatabaseHosts(String databaseName, CommandContext context, List<String> hostNames) {
+	private List<String> determineHostNamesBasedOnDatabaseHosts(String databaseName, CommandContext context, List<String> hostNames) {
 		Map<String, List<String>> databaseHosts = context.getAppConfig().getDatabaseHosts();
 		if (databaseHosts != null) {
 			List<String> databaseHostNames = databaseHosts.get(databaseName);

--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/DistributedReplicaBuilderStrategy.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/DistributedReplicaBuilderStrategy.java
@@ -32,7 +32,7 @@ public class DistributedReplicaBuilderStrategy extends AbstractReplicaBuilderStr
 		List<String> replicaDataDirectories, ForestNamingStrategy fns)
 	{
 		final String databaseName = forestPlan.getDatabaseName();
-		final List<String> hostNames = forestPlan.getReplicaHostNames();
+		final List<String> hostNames = forestPlan.getHostNames();
 		final int replicaCount = forestPlan.getReplicaCount();
 
 		HashMap<String, List<Forest>> hostToForests = new HashMap<>();

--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestBuilder.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestBuilder.java
@@ -158,7 +158,7 @@ public class ForestBuilder extends LoggingObject {
 	 */
 	public void addReplicasToForests(List<Forest> forests, ForestPlan forestPlan, AppConfig appConfig, List<String> dataDirectories) {
 		final String databaseName = forestPlan.getDatabaseName();
-		final List<String> hostNames = forestPlan.getReplicaHostNames();
+		final List<String> hostNames = forestPlan.getHostNames();
 		final int replicaCount = forestPlan.getReplicaCount();
 
 		if (replicaCount >= hostNames.size()) {

--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestHostNames.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestHostNames.java
@@ -17,21 +17,17 @@ package com.marklogic.appdeployer.command.forests;
 
 import java.util.List;
 
+// This is no longer needed now that it doesn't capture replica host names as well.
+// Will remove this in favor of a List<String> in the next PR.
 public class ForestHostNames {
 
 	private List<String> primaryForestHostNames;
-	private List<String> replicaForestHostNames;
 
-	public ForestHostNames(List<String> primaryForestHostNames, List<String> replicaForestHostNames) {
+	public ForestHostNames(List<String> primaryForestHostNames) {
 		this.primaryForestHostNames = primaryForestHostNames;
-		this.replicaForestHostNames = replicaForestHostNames;
 	}
 
 	public List<String> getPrimaryForestHostNames() {
 		return primaryForestHostNames;
-	}
-
-	public List<String> getReplicaForestHostNames() {
-		return replicaForestHostNames;
 	}
 }

--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestPlan.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestPlan.java
@@ -26,7 +26,6 @@ public class ForestPlan {
 
 	private String databaseName;
 	private List<String> hostNames;
-	private List<String> replicaHostNames;
 	private String template;
 	private int forestsPerDataDirectory = 1;
 	private List<Forest> existingForests = new ArrayList<>();
@@ -37,15 +36,9 @@ public class ForestPlan {
 		this(databaseName, Arrays.asList(hostNames));
 	}
 
-	/**
-	 * @param databaseName
-	 * @param hostNames    the list of hosts that primary and replica forests can be created on. If the list of replica
-	 *                     forest host names differs, use withReplicaHostNames
-	 */
 	public ForestPlan(String databaseName, List<String> hostNames) {
 		this.databaseName = databaseName;
 		this.hostNames = hostNames;
-		this.replicaHostNames = hostNames;
 	}
 
 	public ForestPlan withTemplate(String template) {
@@ -65,18 +58,6 @@ public class ForestPlan {
 
 	public ForestPlan withReplicaCount(int count) {
 		this.replicaCount = count;
-		return this;
-	}
-
-	/**
-	 * Confusingly, this is only used - at least as of 6.0.0 - when previewing forest creation. It is not used when
-	 * actually configuring forest replicas.
-	 *
-	 * @param replicaHostNames
-	 * @return
-	 */
-	public ForestPlan withReplicaHostNames(List<String> replicaHostNames) {
-		this.replicaHostNames = replicaHostNames;
 		return this;
 	}
 
@@ -112,10 +93,6 @@ public class ForestPlan {
 
 	public List<Forest> getExistingForests() {
 		return existingForests;
-	}
-
-	public List<String> getReplicaHostNames() {
-		return replicaHostNames;
 	}
 
 	/**

--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestPlanner.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ForestPlanner.java
@@ -10,6 +10,7 @@ import com.marklogic.appdeployer.command.databases.DeployDatabaseCommand;
 import com.marklogic.appdeployer.command.databases.DeployOtherDatabasesCommand;
 import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.api.forest.Forest;
+import com.marklogic.mgmt.resource.hosts.HostManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +28,7 @@ public class ForestPlanner {
         this.manageClient = manageClient;
     }
 
-    public List<Forest> previewForestPlan(String database, AppConfig appConfig) {
+    public List<Forest> previewForestPlan(String databaseName, AppConfig appConfig) {
         // We unfortunately still need a CommandContext here, even though this is just for previewing forests. The
         // classes that this depends on would need to be modified first to only require an AppConfig and/or ManageClient.
         final CommandContext context = new CommandContext(appConfig, this.manageClient, null);
@@ -35,18 +36,31 @@ public class ForestPlanner {
         List<DatabasePlan> plans = new DeployOtherDatabasesCommand().buildDatabasePlans(context);
         DeployDatabaseCommand dbCommand = null;
         for (DatabasePlan plan : plans) {
-            if (plan.getDatabaseName().equals(database)) {
+            if (plan.getDatabaseName().equals(databaseName)) {
                 dbCommand = plan.getDeployDatabaseCommand();
                 break;
             }
         }
         if (dbCommand == null) {
-            throw new IllegalArgumentException("Did not find any database plan with a database name of: " + database);
+            throw new IllegalArgumentException("Did not find any database plan with a database name of: " + databaseName);
         }
 
-        DeployForestsCommand deployForestsCommand = dbCommand.buildDeployForestsCommand(database, context);
-        return deployForestsCommand != null ?
-                deployForestsCommand.buildForests(context, true) :
+        DeployForestsCommand deployForestsCommand = dbCommand.buildDeployForestsCommand(databaseName, context);
+        List<Forest> forests = deployForestsCommand != null ?
+                deployForestsCommand.buildForests(context) :
                 new ArrayList<>();
+
+        ConfigureForestReplicasCommand replicasCommand = new ConfigureForestReplicasCommand();
+
+        if (forests.isEmpty()) {
+            // The list of forests may be empty in case all primary forests have been created. But the user may be
+            // requesting replicas now, so we need to fetch the existing primary forests (if any exist).
+            forests = replicasCommand.determineForestsNeedingReplicas(databaseName, context);
+            forests = replicasCommand.removeForestDetails(forests);
+        }
+
+        List<String> allHostNames = new HostManager(context.getManageClient()).getHostNames();
+        new ConfigureForestReplicasCommand().addReplicasToForests(databaseName, forests, allHostNames, context);
+        return forests;
     }
 }

--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ZoneAwareReplicaBuilderStrategy.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/forests/ZoneAwareReplicaBuilderStrategy.java
@@ -24,7 +24,7 @@ class ZoneAwareReplicaBuilderStrategy extends AbstractReplicaBuilderStrategy {
 			if (hostToForests.containsKey(host)) {
 				hostToForests.get(host).add(f);
 			} else {
-				ArrayList<Forest> hostForests = new ArrayList<>();
+				List<Forest> hostForests = new ArrayList<>();
 				hostForests.add(f);
 				hostToForests.put(host, hostForests);
 			}
@@ -36,13 +36,10 @@ class ZoneAwareReplicaBuilderStrategy extends AbstractReplicaBuilderStrategy {
 			hosts.add(new ForestReplicaPlanner.Host(host, zone, hostForests));
 		});
 
-		List<ForestReplicaPlanner.Host> allAvailableHosts = null;
-		if (forestPlan.getReplicaHostNames() != null) {
-			allAvailableHosts = new ArrayList<>();
-			for (String hostName : forestPlan.getReplicaHostNames()) {
-				final String zone = forestPlan.getHostsToZones() != null ? forestPlan.getHostsToZones().get(hostName) : null;
-				allAvailableHosts.add(new ForestReplicaPlanner.Host(hostName, zone));
-			}
+		List<ForestReplicaPlanner.Host> allAvailableHosts = new ArrayList<>();
+		for (String hostName : forestPlan.getHostNames()) {
+			final String zone = forestPlan.getHostsToZones() != null ? forestPlan.getHostsToZones().get(hostName) : null;
+			allAvailableHosts.add(new ForestReplicaPlanner.Host(hostName, zone));
 		}
 
 		ForestReplicaPlanner.assignReplicas(hosts, forestPlan.getReplicaCount(), allAvailableHosts);

--- a/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/BuildForestReplicaTest.java
+++ b/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/BuildForestReplicaTest.java
@@ -22,7 +22,6 @@ import com.marklogic.mgmt.api.forest.ForestReplica;
 import com.marklogic.mgmt.util.SimplePropertySource;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +29,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BuildForestReplicaTest {
 
@@ -140,34 +138,6 @@ class BuildForestReplicaTest {
 		assertEquals(120, replicaCount.get(), "Expecting 120 replicas; we have 40 forests, and we expect 3 replicas for each");
 		Stream.of("host1", "host2", "host3", "host4").forEach(host -> {
 			assertEquals(30, hostToReplicaCounts.get(host).get(), "Each host should have 30 replicas, as there are 120 total");
-		});
-	}
-
-	/**
-	 * Verifies that replicaHostNames is used for generating the replicas. This is for databases that are configured
-	 * to have their primary forests on a single host, which is often the case for modules, schemas, and triggers.
-	 */
-	@Test
-	public void primaryForestsOnOneHost() {
-		AppConfig appConfig = newAppConfig("mlForestsPerHost", "db,2");
-
-		ForestPlan plan = new ForestPlan("db", "host1").withReplicaCount(2);
-		assertEquals(1, plan.getHostNames().size());
-		assertEquals(1, plan.getReplicaHostNames().size());
-		plan.withReplicaHostNames(Arrays.asList("host1", "host2", "host3"));
-		assertEquals(1, plan.getHostNames().size());
-		assertEquals(3, plan.getReplicaHostNames().size());
-
-		List<Forest> forests = builder.buildForests(plan, appConfig);
-
-		assertEquals(2, forests.size());
-		forests.forEach(forest -> {
-			assertEquals("host1", forest.getHost());
-			assertEquals(2, forest.getForestReplica().size());
-			for (ForestReplica replica : forest.getForestReplica()) {
-				String host = replica.getHost();
-				assertTrue(host.equals("host2") || host.equals("host3"), "Unexpected host for replica: " + host);
-			}
 		});
 	}
 

--- a/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/CreateForestsOnOneHostTest.java
+++ b/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/CreateForestsOnOneHostTest.java
@@ -42,12 +42,10 @@ public class CreateForestsOnOneHostTest {
 
 		ForestHostNames hostNames = command.determineHostNamesForForest(context, new ArrayList<>());
 		assertEquals(3, hostNames.getPrimaryForestHostNames().size());
-		assertEquals(3, hostNames.getReplicaForestHostNames().size());
 
 		appConfig.addDatabaseWithForestsOnOneHost("test-db");
 		hostNames = command.determineHostNamesForForest(context, new ArrayList<>());
 		assertEquals(1, hostNames.getPrimaryForestHostNames().size());
-		assertEquals(3, hostNames.getReplicaForestHostNames().size());
 	}
 
 	/**
@@ -74,7 +72,7 @@ public class CreateForestsOnOneHostTest {
 		assertEquals("host2", hostNames.getPrimaryForestHostNames().get(0), "Because there's already a forest on " +
 			"host2, that should be the primary forest host name, even though host1 is first in the list");
 
-		List<Forest> forestsToCreate = command.buildForests(context, false, existingForests);
+		List<Forest> forestsToCreate = command.buildForests(context, existingForests);
 		assertEquals(1, forestsToCreate.size(), "Because forests per host is 2 and host2 already has 1 forest, 1 more " +
 			"forest needs to be created");
 		assertEquals("host2", forestsToCreate.get(0).getHost());

--- a/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/CreateForestsOnSpecificHostsTest.java
+++ b/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/forests/CreateForestsOnSpecificHostsTest.java
@@ -19,12 +19,16 @@ import com.marklogic.appdeployer.AppConfig;
 import com.marklogic.appdeployer.DefaultAppConfigFactory;
 import com.marklogic.appdeployer.command.CommandContext;
 import com.marklogic.mgmt.util.SimplePropertySource;
-import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
 
-public class CreateForestsOnSpecificHostsTest  {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CreateForestsOnSpecificHostsTest {
 
 	@Test
 	public void test() {
@@ -42,7 +46,6 @@ public class CreateForestsOnSpecificHostsTest  {
 		// Verify we get all 3 hosts back when nothing special is configured
 		ForestHostNames hostNames = command.determineHostNamesForForest(context, new ArrayList<>());
 		assertEquals(3, hostNames.getPrimaryForestHostNames().size());
-		assertEquals(3, hostNames.getReplicaForestHostNames().size());
 
 		// Select 2 of the 3 hosts for test-db
 		Properties props = new Properties();
@@ -53,7 +56,6 @@ public class CreateForestsOnSpecificHostsTest  {
 
 		hostNames = command.determineHostNamesForForest(context, new ArrayList<>());
 		assertEquals(2, hostNames.getPrimaryForestHostNames().size());
-		assertEquals(2, hostNames.getReplicaForestHostNames().size());
 		assertTrue(hostNames.getPrimaryForestHostNames().contains("host1"));
 		assertTrue(hostNames.getPrimaryForestHostNames().contains("host2"));
 
@@ -63,7 +65,6 @@ public class CreateForestsOnSpecificHostsTest  {
 		context = new CommandContext(appConfig, null, null);
 		hostNames = command.determineHostNamesForForest(context, new ArrayList<>());
 		assertEquals(1, hostNames.getPrimaryForestHostNames().size());
-		assertEquals(1, hostNames.getReplicaForestHostNames().size());
 		assertTrue(hostNames.getPrimaryForestHostNames().contains("host2"));
 	}
 }


### PR DESCRIPTION
Removed replica creation from DeployForestsCommand. ForestPlanner now handles both forests and replicas for the sake of previewing forest creation.

There's a lot more that can be done here - namely, in moving logic out of the command classes into a "forest calculator" class that handles all the logic for building and optionally saving a set of forests. But this at least gets rid of the two paths for replica creation.
