### PR TITLE
MLE-23174 Hiding retry capability for now

### DIFF
--- a/ml-app-deployer/src/main/java/com/marklogic/rest/util/RestConfig.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/rest/util/RestConfig.java
@@ -9,6 +9,7 @@ import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
 import com.marklogic.client.ext.modulesloader.ssl.SimpleX509TrustManager;
 import com.marklogic.client.ext.ssl.SslConfig;
 import com.marklogic.client.ext.ssl.SslUtil;
+import okhttp3.OkHttpClient;
 import org.springframework.util.StringUtils;
 
 import javax.net.ssl.SSLContext;
@@ -50,11 +51,9 @@ public class RestConfig {
 	private String trustStoreType;
 	private String trustStoreAlgorithm;
 
-	private boolean retryOnConnectionFailure = false;
-	private int maxRetries = 3;
-	private long initialRetryDelayMs = 1000;
-	private double retryBackoffMultiplier = 2;
-	private long maxRetryDelayMs = 10000;
+	// Added in 6.0.0 as an extension mechanism until this is available
+	// in DatabaseClientBuilder in the MarkLogic Java Client.
+	private DatabaseClientFactory.ClientConfigurator<OkHttpClient.Builder> clientConfigurator;
 
 	public RestConfig() {
 	}
@@ -475,44 +474,11 @@ public class RestConfig {
 		this.oauthToken = oauthToken;
 	}
 
-
-	public boolean isRetryOnConnectionFailure() {
-		return retryOnConnectionFailure;
+	protected DatabaseClientFactory.ClientConfigurator<OkHttpClient.Builder> getClientConfigurator() {
+		return clientConfigurator;
 	}
 
-	public void setRetryOnConnectionFailure(boolean retryOnConnectionFailure) {
-		this.retryOnConnectionFailure = retryOnConnectionFailure;
-	}
-
-	public int getMaxRetries() {
-		return maxRetries;
-	}
-
-	public void setMaxRetries(int maxRetries) {
-		this.maxRetries = maxRetries;
-	}
-
-	public long getInitialRetryDelayMs() {
-		return initialRetryDelayMs;
-	}
-
-	public void setInitialRetryDelayMs(long initialRetryDelayMs) {
-		this.initialRetryDelayMs = initialRetryDelayMs;
-	}
-
-	public double getRetryBackoffMultiplier() {
-		return retryBackoffMultiplier;
-	}
-
-	public void setRetryBackoffMultiplier(double retryBackoffMultiplier) {
-		this.retryBackoffMultiplier = retryBackoffMultiplier;
-	}
-
-	public long getMaxRetryDelayMs() {
-		return maxRetryDelayMs;
-	}
-
-	public void setMaxRetryDelayMs(long maxRetryDelayMs) {
-		this.maxRetryDelayMs = maxRetryDelayMs;
+	protected void setClientConfigurator(DatabaseClientFactory.ClientConfigurator<OkHttpClient.Builder> clientConfigurator) {
+		this.clientConfigurator = clientConfigurator;
 	}
 }

--- a/ml-app-deployer/src/main/java/com/marklogic/rest/util/RestTemplateUtil.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/rest/util/RestTemplateUtil.java
@@ -29,14 +29,8 @@ public class RestTemplateUtil {
 			OkHttpClient.Builder builder = OkHttpClientBuilderFactory
 				.newOkHttpClientBuilder(bean.getHost(), bean.getSecurityContext());
 
-			if (config.isRetryOnConnectionFailure()) {
-				RetryInterceptor retryInterceptor = new RetryInterceptor(
-					config.getMaxRetries(),
-					config.getInitialRetryDelayMs(),
-					config.getRetryBackoffMultiplier(),
-					config.getMaxRetryDelayMs()
-				);
-				builder = builder.addInterceptor(retryInterceptor);
+			if (config.getClientConfigurator() != null) {
+				config.getClientConfigurator().configure(builder);
 			}
 
 			client = builder.build();

--- a/ml-app-deployer/src/test/java/com/marklogic/mgmt/AbstractMgmtTest.java
+++ b/ml-app-deployer/src/test/java/com/marklogic/mgmt/AbstractMgmtTest.java
@@ -9,6 +9,7 @@ import com.marklogic.junit5.MarkLogicVersionSupplier;
 import com.marklogic.mgmt.admin.AdminConfig;
 import com.marklogic.mgmt.admin.AdminManager;
 import com.marklogic.mgmt.resource.clusters.ClusterManager;
+import com.marklogic.rest.util.TestConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/ml-app-deployer/src/test/java/com/marklogic/rest/util/RetryInterceptor.java
+++ b/ml-app-deployer/src/test/java/com/marklogic/rest/util/RetryInterceptor.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
 package com.marklogic.rest.util;
 
 import com.marklogic.client.ext.helper.LoggingObject;

--- a/ml-app-deployer/src/test/java/com/marklogic/rest/util/TestConfig.java
+++ b/ml-app-deployer/src/test/java/com/marklogic/rest/util/TestConfig.java
@@ -1,8 +1,10 @@
 /*
  * Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
-package com.marklogic.mgmt;
+package com.marklogic.rest.util;
 
+import com.marklogic.mgmt.DefaultManageConfigFactory;
+import com.marklogic.mgmt.ManageConfig;
 import com.marklogic.mgmt.admin.AdminConfig;
 import com.marklogic.mgmt.admin.DefaultAdminConfigFactory;
 import com.marklogic.mgmt.util.SimplePropertySource;
@@ -72,10 +74,9 @@ public class TestConfig {
 		// Clean the JSON by default
 		config.setCleanJsonPayloads(true);
 
-		config.setRetryOnConnectionFailure(true);
-		config.setRetryBackoffMultiplier(2);
-		config.setMaxRetries(3);
-		config.setMaxRetryDelayMs(5000);
+		config.setClientConfigurator(builder ->
+			builder.addInterceptor(new com.marklogic.rest.util.RetryInterceptor(3, 1000, 2, 5000)));
+
 		return config;
 	}
 


### PR DESCRIPTION
This really needs to be supported in the Java Client in order for it to be done correctly - specifically in the DatabaseClientBuilder class. Otherwise we can only support it in here for the Manage/Admin connections but not the REST / App-Services connections.

Had to move TestConfig so that it could invoke the protected method for specifying a ClientConfigurator, which thus keeps it out of the public API.
