### PR TITLE
MLE-24703 Bumped to Java Client 8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,22 +14,18 @@ subprojects {
 
 	repositories {
 		mavenCentral()
-		mavenLocal()
-		maven {
-			url = "https://bed-artifactory.bedford.progress.com:443/artifactory/ml-maven-snapshots/"
-		}
 	}
 
 	dependencies {
 		// Without this, once using JUnit 5.12 or higher, Gradle will not find any tests and report an error of:
 		// org.junit.platform.commons.JUnitException: TestEngine with ID 'junit-jupiter' failed to discover tests
-		testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.13.4"
+		testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.14.0"
 
-		testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
+		testImplementation 'org.junit.jupiter:junit-jupiter:5.14.0'
 		testImplementation "org.springframework:spring-test:${springVersion}"
 
 		// Forcing Spring to use logback instead of commons-logging
-		testImplementation "ch.qos.logback:logback-classic:1.5.18"
+		testImplementation "ch.qos.logback:logback-classic:1.5.19"
 		testImplementation 'org.slf4j:jcl-over-slf4j:2.0.17'
 		testImplementation 'org.slf4j:slf4j-api:2.0.17'
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ version=6.1-SNAPSHOT
 
 # See https://github.com/FasterXML/jackson for more information the Jackson libraries.
 # This should match the version used by the MarkLogic Java Client.
-jacksonVersion=2.19.0
+jacksonVersion=2.20.0
 
 springVersion=6.2.11
 

--- a/ml-app-deployer/build.gradle
+++ b/ml-app-deployer/build.gradle
@@ -15,13 +15,13 @@ dependencies {
 
 	// Must depend on this as it's not an API dependency of the Java Client, and we have some code
 	// that requires OkHttp for compilation.
-	implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+	implementation 'com.squareup.okhttp3:okhttp:5.2.0'
 
 	// For parsing/manipulating XML.
 	implementation 'org.jdom:jdom2:2.0.6.1'
 
 	// For EqualsBuilder; added in 3.8.1 to support detecting if a mimetype's properties have changed or not
-	implementation "org.apache.commons:commons-lang3:3.18.0"
+	implementation "org.apache.commons:commons-lang3:3.19.0"
 
 	// For PreviewInterceptor; can be excluded if that feature is not used
 	implementation("com.flipkart.zjsonpatch:zjsonpatch:0.4.16") {

--- a/ml-javaclient-util/build.gradle
+++ b/ml-javaclient-util/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	api 'com.marklogic:marklogic-client-api:8.0-SNAPSHOT'
+	api 'com.marklogic:marklogic-client-api:8.0.0'
 	api 'com.marklogic:marklogic-xcc:12.0.0'
 
 	// API dependency as some Spring classes, like Resource, are used throughout this project.


### PR DESCRIPTION
Will likely bump to a snapshot build of marklogic-junit5 until that has 2.0 released.
