### PR TITLE
MLE-24717 Bumping marklogic-junit5 dependency

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -11,13 +11,13 @@ product and version for which you are requesting source code.
 Third Party Notices
 
 commons-io 2.20.0 (Apache-2.0)
-commons-lang3 3.18.0 (Apache-2.0)
-jackson-databind 2.19.0 (Apache-2.0)
+commons-lang3 3.19.0 (Apache-2.0)
+jackson-databind 2.20.0 (Apache-2.0)
 jaxen 2.0.0 (Apache-2.0)
 jdom2 2.0.6.1 (Apache-2.0)
-marklogic-client-api 7.2.0 (Apache-2.0)
+marklogic-client-api 8.0.0 (Apache-2.0)
 marklogic-xcc 12.0.0 (Apache-2.0)
-okhttp 4.12.0 (Apache-2.0)
+okhttp 5.2.0 (Apache-2.0)
 slf4j-api 2.0.17 (MIT)
 spring-web 6.2.11 (Apache-2.0)
 zjsonpatch 0.4.16 (Apache-2.0)

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,11 @@ subprojects {
 
 	repositories {
 		mavenCentral()
+
+		// Temporarily using to depend on marklogic-junit5 snapshot until it's released.
+		maven {
+			url = "https://bed-artifactory.bedford.progress.com:443/artifactory/ml-maven-snapshots/"
+		}
 	}
 
 	dependencies {

--- a/examples/unit-test-project/README.md
+++ b/examples/unit-test-project/README.md
@@ -12,7 +12,7 @@ include this by default (not every ml-gradle user will use marklogic-unit-test),
         mavenCentral()
       }
       dependencies {
-        classpath "com.marklogic:marklogic-unit-test-client:1.1.0"
+        classpath "com.marklogic:marklogic-unit-test-client:1.5.0"
       }
     }
 

--- a/ml-app-deployer/build.gradle
+++ b/ml-app-deployer/build.gradle
@@ -35,8 +35,6 @@ dependencies {
 	testImplementation 'commons-io:commons-io:2.19.0'
 	testImplementation 'xmlunit:xmlunit:1.6'
 
-	testImplementation ("com.marklogic:marklogic-junit5:1.5.0") {
-		// Use the version of ml-javaclient-util within this repository.
-		exclude module: "ml-javaclient-util"
-	}
+	// Gradle will alter this to use the ml-javaclient-util project in this repository.
+	testImplementation "com.marklogic:marklogic-junit5:2.0-SNAPSHOT"
 }

--- a/ml-gradle/build.gradle
+++ b/ml-gradle/build.gradle
@@ -11,7 +11,8 @@ dependencies {
 	// For tasks that need to fiddle with the filesystem.
 	implementation "commons-io:commons-io:2.20.0"
 
-	// For UnitTestTask.
+	// For UnitTestTask. Compiling against 1.5.0 until 2.0.0 is released. But this does not
+	// impact users, who must provide their own version of this library in order to use the task.
 	compileOnly ("com.marklogic:marklogic-unit-test-client:1.5.0") {
 		// Prefer the Java Client version coming from ml-javaclient-util.
 		exclude module: "marklogic-client-api"


### PR DESCRIPTION
This is just to verify the ml-app-deployer tests run fine using marklogic-junit5 2.x. This has no impact on users.
