### PR TITLE
MLE-25708 Deprecating support for entity services

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ subprojects {
 		testImplementation "org.springframework:spring-test:${springVersion}"
 
 		// Forcing Spring to use logback instead of commons-logging
-		testImplementation "ch.qos.logback:logback-classic:1.5.19"
+		testImplementation "ch.qos.logback:logback-classic:1.5.21"
 		testImplementation 'org.slf4j:jcl-over-slf4j:2.0.17'
 		testImplementation 'org.slf4j:slf4j-api:2.0.17'
 	}

--- a/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/es/GenerateModelArtifactsCommand.java
+++ b/ml-app-deployer/src/main/java/com/marklogic/appdeployer/command/es/GenerateModelArtifactsCommand.java
@@ -22,7 +22,10 @@ import java.util.List;
  * Generates Entity Services model artifacts based on model definitions. This is implemented as a command, though it's
  * not likely to be invoked as part of e.g. an "mlDeploy" call in ml-gradle. But implementing it as a command does
  * allow for that possibility, and it's also easy to invoke by itself in ml-gradle too.
+ *
+ * @deprecated since 6.2.0
  */
+@Deprecated
 public class GenerateModelArtifactsCommand extends AbstractCommand {
 
 	// Should be very rare to need to override this, but just in case

--- a/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/es/GenerateModelArtifactsTest.java
+++ b/ml-app-deployer/src/test/java/com/marklogic/appdeployer/command/es/GenerateModelArtifactsTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Deprecated
 public class GenerateModelArtifactsTest extends AbstractAppDeployerTest {
 
 	@AfterEach

--- a/ml-javaclient-util/src/main/java/com/marklogic/client/ext/es/CodeGenerationRequest.java
+++ b/ml-javaclient-util/src/main/java/com/marklogic/client/ext/es/CodeGenerationRequest.java
@@ -3,6 +3,10 @@
  */
 package com.marklogic.client.ext.es;
 
+/**
+ * @deprecated since 6.2.0
+ */
+@Deprecated
 public class CodeGenerationRequest {
 
 	private boolean generateDatabaseProperties = true;

--- a/ml-javaclient-util/src/main/java/com/marklogic/client/ext/es/EntityServicesManager.java
+++ b/ml-javaclient-util/src/main/java/com/marklogic/client/ext/es/EntityServicesManager.java
@@ -16,7 +16,9 @@ import java.util.Objects;
 
 /**
  * Handles loading a model and then making calls to generate code for it.
+ * @deprecated since 6.2.0
  */
+@Deprecated
 public class EntityServicesManager {
 
 	private String modelCollection = "http://marklogic.com/entity-services/models";

--- a/ml-javaclient-util/src/main/java/com/marklogic/client/ext/es/GeneratedCode.java
+++ b/ml-javaclient-util/src/main/java/com/marklogic/client/ext/es/GeneratedCode.java
@@ -3,6 +3,10 @@
  */
 package com.marklogic.client.ext.es;
 
+/**
+ * @deprecated since 6.2.0
+ */
+@Deprecated
 public class GeneratedCode {
 
 	private String title;

--- a/ml-javaclient-util/src/test/java/com/marklogic/client/ext/es/EntityServicesTest.java
+++ b/ml-javaclient-util/src/test/java/com/marklogic/client/ext/es/EntityServicesTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests against the default Documents database. Doesn't clear it out before or after.
  */
+@Deprecated
 public class EntityServicesTest extends AbstractIntegrationTest {
 
 	private final static String MODEL = "{\n" +


### PR DESCRIPTION
This is solely the domain of DataHub now and should have been deprecated / removed a long time ago.
